### PR TITLE
RLFD: fix logical error to avoid false positives

### DIFF
--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -44,7 +44,7 @@ var (
 
     // trace for testing
     trace *TraceData
-    pcapFilename = "../resource/equinix-chicago.dirA.20160406-125912.UTC.anon.pcap"
+    pcapFilename = "../resource/10K-test-pkts"
     maxNumPkts = 10000
     pktNumInBinary int     // number of packets written into the binary file
 )
@@ -241,7 +241,10 @@ func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
 	blackListBD := make(map[complex128]int)
 
 	//initialize detectors
-	cd := clef.NewClefDtctr(p, alpha, beta_th, uint32(beta), uint32(gamma), t_l)
+	eardet := eardet.NewConfigedEardetDtctr(ed_counter_num, alpha, beta_l, gamma_l, p)
+	rlfd1 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
+	rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
+	cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2)
 	bd := baseline.NewBaselineDtctr(beta, gamma)
 
 	//initialize packets

--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -44,7 +44,7 @@ var (
 
     // trace for testing
     trace *TraceData
-    pcapFilename = "../resource/10K-test-pkts"
+    pcapFilename = "../resource/equinix-chicago.dirA.20160406-125912.UTC.anon.pcap"
     maxNumPkts = 10000
     pktNumInBinary int     // number of packets written into the binary file
 )
@@ -160,7 +160,7 @@ func TestRLFDPerformanceAgainstBaseline(t *testing.T) {
 	blackListBD := make(map[uint32]int)
 
 	//initialize detectors
-	rd := rlfd.NewRlfdDtctr(uint32(beta), uint32(gamma), t_l)
+	rd := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
 	bd := baseline.NewBaselineDtctr(beta, gamma)
 
 	//initialize packets
@@ -683,7 +683,7 @@ func BenchmarkWithTraceLoadedRlfd(b *testing.B) {
 	if trace == nil {
         trace = loadPCAPFile(pcapFilename, maxNumPkts)
     }
-	detector := rlfd.NewRlfdDtctr(uint32(beta), uint32(gamma), 100)
+	detector := rlfd.NewRlfdDtctr(uint32(beta), gamma, 100)
 	var flowID uint32
 	var pkt *caidaPkt
 	murmur3.ResetSeed()

--- a/clef/clef.go
+++ b/clef/clef.go
@@ -29,7 +29,7 @@ type ClefDtctr struct {
 	resultsRlfd2 chan bool
 }
 
-func NewClefDtctr(linkCap float64, alpha, beta_th, beta, gamma uint32, t_l time.Duration) *ClefDtctr {
+func NewClefDtctr(linkCap float64, alpha, beta_th, beta uint32, gamma, t_l time.Duration) *ClefDtctr {
 	cd := &ClefDtctr{}
 
 	//set detectors

--- a/clef/clef.go
+++ b/clef/clef.go
@@ -29,13 +29,13 @@ type ClefDtctr struct {
 	resultsRlfd2 chan bool
 }
 
-func NewClefDtctr(linkCap float64, alpha, beta_th, beta uint32, gamma, t_l time.Duration) *ClefDtctr {
+func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr) *ClefDtctr {
 	cd := &ClefDtctr{}
 
 	//set detectors
-	cd.eardet = eardet.NewEardetDtctr(128, alpha, beta_th, linkCap)
-	cd.rlfd1 = rlfd.NewRlfdDtctr(beta, gamma, t_l)
-	cd.rlfd2 = rlfd.NewRlfdDtctr(beta, gamma, t_l)
+	cd.eardet = eardet
+	cd.rlfd1 = rlfd1
+	cd.rlfd2 = rlfd2
 
 	//create channels
 	cd.packetsForEardet = make(chan pktTriple, 3)

--- a/rlfd/rlfd.go
+++ b/rlfd/rlfd.go
@@ -51,11 +51,11 @@ type RlfdDtctr struct {
 }
 
 //returns a pointer to a new rlfdDtctr
-func NewRlfdDtctr(beta, gamma uint32, t_l time.Duration) *RlfdDtctr {
+func NewRlfdDtctr(beta uint32, gamma float64, t_l time.Duration) *RlfdDtctr {
 	rd := &RlfdDtctr{}
 
 	rd.t_l = t_l
-	rd.th_rlfd = gamma*uint32(t_l) + beta
+	rd.th_rlfd = uint32(gamma*float64(t_l)) + beta
 	rd.level = 0
 	rd.bitmaskIndex = ((1 << s) - 1) << (32 - s) //(2^s - 1) << (32 - s)
 	rd.bitmaskPath = 0
@@ -134,7 +134,7 @@ func (rd *RlfdDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool {
 				return true
 			} else if c.count > rd.th_rlfd && !alt {
 				return true
-			} else if rd.counters[altIndex].count > rd.th_rlfd {
+			} else if alt && rd.counters[altIndex].count > rd.th_rlfd {
 				return true
 			}
 		//we are not on the lowest level


### PR DESCRIPTION
According to the paper, RLFD has no false positives by design. However, there were false positives when running the test for the RLFD detector. This was mostly due to a logical error in the thresholding at the lowest counter level: The counter at the alternative index (cf. Cuckoo hashing) was always checked, even when the currently checked flow was not hashed to that counter. If there was (another) misbehaving flow at that alternative index, RLFD would report that the currently checked flow was misbehaving, leading to false positives. However, there was an easy fix for that.

Moreover, the allowed rate gamma was cut to zero (by converting it to uint32), leading to distortion of results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lfd/7)
<!-- Reviewable:end -->
