### PR TITLE
Carry-over, AES hashing, watchlist & blacklist

### DIFF
--- a/aeshash/aeshash.go
+++ b/aeshash/aeshash.go
@@ -1,0 +1,55 @@
+// This package leverages the AES block cipher for hashing
+package aeshash
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+)
+
+//---------------------------------------------------
+// Wrapper object for AES hashing
+type AESHasher struct {
+	seed []byte
+	hasher cipher.Block
+	output []byte
+}
+
+//---------------------------------------------------
+// Object Instantiation
+func NewAESHasher(seed []byte) *AESHasher {
+	aesh := &AESHasher{}
+	aesh.SetSeed(seed)
+	return aesh
+}
+
+//---------------------------------------------------
+// (Re)set seed
+func (aesh *AESHasher) SetSeed(seed []byte) {
+
+	aesh.seed = make([]byte, len(seed))
+	copy(aesh.seed, seed)
+
+	var err error
+	aesh.hasher, err = aes.NewCipher(aesh.seed)
+	if (err != nil) { panic(err) }
+
+	aesh.output = make([]byte, len(seed))
+
+}
+
+//---------------------------------------------------
+// Use AES encryption as a hash function on an input
+func (aesh *AESHasher) Hash_uint32(input *[16]byte) uint32 {
+	aesh.hasher.Encrypt(aesh.output, (*input)[:])
+	return binary.LittleEndian.Uint32(aesh.output)
+
+}
+
+//---------------------------------------------------
+// Use AES encryption as a hash function on an input
+func (aesh *AESHasher) Hash_uint64(input *[16]byte) uint64 {
+	aesh.hasher.Encrypt(aesh.output, (*input)[:])
+	return binary.LittleEndian.Uint64(aesh.output)
+
+}

--- a/aeshash/aeshash.go
+++ b/aeshash/aeshash.go
@@ -2,54 +2,54 @@
 package aeshash
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"encoding/binary"
+    "crypto/aes"
+    "crypto/cipher"
+    "encoding/binary"
 )
 
 //---------------------------------------------------
 // Wrapper object for AES hashing
 type AESHasher struct {
-	seed []byte
-	hasher cipher.Block
-	output []byte
+    seed []byte
+    hasher cipher.Block
+    output []byte
 }
 
 //---------------------------------------------------
 // Object Instantiation
 func NewAESHasher(seed []byte) *AESHasher {
-	aesh := &AESHasher{}
-	aesh.SetSeed(seed)
-	return aesh
+    aesh := &AESHasher{}
+    aesh.SetSeed(seed)
+    return aesh
 }
 
 //---------------------------------------------------
 // (Re)set seed
 func (aesh *AESHasher) SetSeed(seed []byte) {
 
-	aesh.seed = make([]byte, len(seed))
-	copy(aesh.seed, seed)
+    aesh.seed = make([]byte, len(seed))
+    copy(aesh.seed, seed)
 
-	var err error
-	aesh.hasher, err = aes.NewCipher(aesh.seed)
-	if (err != nil) { panic(err) }
+    var err error
+    aesh.hasher, err = aes.NewCipher(aesh.seed)
+    if (err != nil) { panic(err) }
 
-	aesh.output = make([]byte, len(seed))
+    aesh.output = make([]byte, len(seed))
 
 }
 
 //---------------------------------------------------
 // Use AES encryption as a hash function on an input
 func (aesh *AESHasher) Hash_uint32(input *[16]byte) uint32 {
-	aesh.hasher.Encrypt(aesh.output, (*input)[:])
-	return binary.LittleEndian.Uint32(aesh.output)
+    aesh.hasher.Encrypt(aesh.output, (*input)[:])
+    return binary.LittleEndian.Uint32(aesh.output)
 
 }
 
 //---------------------------------------------------
 // Use AES encryption as a hash function on an input
 func (aesh *AESHasher) Hash_uint64(input *[16]byte) uint64 {
-	aesh.hasher.Encrypt(aesh.output, (*input)[:])
-	return binary.LittleEndian.Uint64(aesh.output)
+    aesh.hasher.Encrypt(aesh.output, (*input)[:])
+    return binary.LittleEndian.Uint64(aesh.output)
 
 }

--- a/aeshash/aeshash_test.go
+++ b/aeshash/aeshash_test.go
@@ -1,0 +1,74 @@
+package aeshash
+
+import (
+	"testing"
+	"fmt"
+	"crypto/rand"
+	"time"
+
+	"github.com/hosslen/lfd/murmur3"
+)
+
+
+//-----------------------------------------------------------
+// Test whether AESHasher computes an expected hash value
+func TestAESHasher(t *testing.T) {
+	seed := []byte("ABCDEFGHIJKLMNOP")
+	aesh := NewAESHasher(seed)
+	input := [16]byte{}
+	copy(input[:], []byte("Hello World!"))
+	output := aesh.Hash_uint32(&input)
+	if (output != 3635243428) {
+		t.Errorf("Wrong hash value.")
+	}
+	fmt.Printf("Hash value: '%d'\n", output)
+}
+
+
+//-----------------------------------------------------------
+// Compare the runtimes of the Murmur3 hash implementation
+//  and the AES hashing implementation
+func TestComparisonWithMurmur3(t *testing.T) {
+
+	// Generate seed
+	seed := make([]byte, 16)
+	_, err := rand.Read(seed)
+	aesh := NewAESHasher(seed)
+	if (err != nil) {
+		fmt.Print("Error: ")
+		fmt.Println(err)
+		return
+	}
+
+	// Prepare inputs
+	const n_inputs = 1000000
+	inputs := [n_inputs](*[16]byte){}
+	for i := 0; i < n_inputs; i++ {
+		inputs[i] = &([16]byte{})
+		_, err := rand.Read((*(inputs[i]))[:])
+		if (err != nil) {
+			fmt.Println(err)
+			break
+		}
+	}
+
+	var start time.Time
+	var elapsed time.Duration
+
+	// Measure Murmur3
+	start = time.Now()
+	for i := 0; i < n_inputs; i++ {
+		murmur3.Murmur3_32_caida(inputs[i])
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("Average time per operation for Murmur3: %.2fns\n", float64(elapsed)/float64(n_inputs))
+
+	// Measure AESHasher
+	start = time.Now()
+	for i := 0; i < n_inputs; i++ {
+		aesh.Hash_uint32(inputs[i])
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("Average time per operation for AESHasher: %.2fns\n", float64(elapsed)/float64(n_inputs))
+
+}

--- a/aeshash/aeshash_test.go
+++ b/aeshash/aeshash_test.go
@@ -1,27 +1,27 @@
 package aeshash
 
 import (
-	"testing"
-	"fmt"
-	"crypto/rand"
-	"time"
+    "testing"
+    "fmt"
+    "crypto/rand"
+    "time"
 
-	"github.com/hosslen/lfd/murmur3"
+    "github.com/hosslen/lfd/murmur3"
 )
 
 
 //-----------------------------------------------------------
 // Test whether AESHasher computes an expected hash value
 func TestAESHasher(t *testing.T) {
-	seed := []byte("ABCDEFGHIJKLMNOP")
-	aesh := NewAESHasher(seed)
-	input := [16]byte{}
-	copy(input[:], []byte("Hello World!"))
-	output := aesh.Hash_uint32(&input)
-	if (output != 3635243428) {
-		t.Errorf("Wrong hash value.")
-	}
-	fmt.Printf("Hash value: '%d'\n", output)
+    seed := []byte("ABCDEFGHIJKLMNOP")
+    aesh := NewAESHasher(seed)
+    input := [16]byte{}
+    copy(input[:], []byte("Hello World!"))
+    output := aesh.Hash_uint32(&input)
+    if (output != 3635243428) {
+        t.Errorf("Wrong hash value.")
+    }
+    fmt.Printf("Hash value: '%d'\n", output)
 }
 
 
@@ -30,45 +30,45 @@ func TestAESHasher(t *testing.T) {
 //  and the AES hashing implementation
 func TestComparisonWithMurmur3(t *testing.T) {
 
-	// Generate seed
-	seed := make([]byte, 16)
-	_, err := rand.Read(seed)
-	aesh := NewAESHasher(seed)
-	if (err != nil) {
-		fmt.Print("Error: ")
-		fmt.Println(err)
-		return
-	}
+    // Generate seed
+    seed := make([]byte, 16)
+    _, err := rand.Read(seed)
+    aesh := NewAESHasher(seed)
+    if (err != nil) {
+        fmt.Print("Error: ")
+        fmt.Println(err)
+        return
+    }
 
-	// Prepare inputs
-	const n_inputs = 1000000
-	inputs := [n_inputs](*[16]byte){}
-	for i := 0; i < n_inputs; i++ {
-		inputs[i] = &([16]byte{})
-		_, err := rand.Read((*(inputs[i]))[:])
-		if (err != nil) {
-			fmt.Println(err)
-			break
-		}
-	}
+    // Prepare inputs
+    const n_inputs = 1000000
+    inputs := [n_inputs](*[16]byte){}
+    for i := 0; i < n_inputs; i++ {
+        inputs[i] = &([16]byte{})
+        _, err := rand.Read((*(inputs[i]))[:])
+        if (err != nil) {
+            fmt.Println(err)
+            break
+        }
+    }
 
-	var start time.Time
-	var elapsed time.Duration
+    var start time.Time
+    var elapsed time.Duration
 
-	// Measure Murmur3
-	start = time.Now()
-	for i := 0; i < n_inputs; i++ {
-		murmur3.Murmur3_32_caida(inputs[i])
-	}
-	elapsed = time.Since(start)
-	fmt.Printf("Average time per operation for Murmur3: %.2fns\n", float64(elapsed)/float64(n_inputs))
+    // Measure Murmur3
+    start = time.Now()
+    for i := 0; i < n_inputs; i++ {
+        murmur3.Murmur3_32_caida(inputs[i])
+    }
+    elapsed = time.Since(start)
+    fmt.Printf("Average time per operation for Murmur3: %.2fns\n", float64(elapsed)/float64(n_inputs))
 
-	// Measure AESHasher
-	start = time.Now()
-	for i := 0; i < n_inputs; i++ {
-		aesh.Hash_uint32(inputs[i])
-	}
-	elapsed = time.Since(start)
-	fmt.Printf("Average time per operation for AESHasher: %.2fns\n", float64(elapsed)/float64(n_inputs))
+    // Measure AESHasher
+    start = time.Now()
+    for i := 0; i < n_inputs; i++ {
+        aesh.Hash_uint32(inputs[i])
+    }
+    elapsed = time.Since(start)
+    fmt.Printf("Average time per operation for AESHasher: %.2fns\n", float64(elapsed)/float64(n_inputs))
 
 }

--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -289,7 +289,7 @@ func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
     //initialize detectors
     eardet := eardet.NewConfigedEardetDtctr(ed_counter_num, alpha, beta_l, gamma_l, p)
     rlfd1 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
-    rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
+    rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, time.Duration((2*7*gamma_h)/(1.5*gamma))*t_l)
     cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2, t_l, gamma, beta, maxWatchlistSize)
     bd := baseline.NewBaselineDtctr(beta, gamma)
 

--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -7,7 +7,7 @@ import (
     "bufio"
     "testing"
     "time"
-    // "unsafe"
+    "unsafe"
 
     "github.com/google/gopacket"
     "github.com/google/gopacket/layers"
@@ -17,8 +17,9 @@ import (
     "github.com/hosslen/lfd/eardet"
     "github.com/hosslen/lfd/murmur3"
     "github.com/hosslen/lfd/rlfd"
+    "github.com/hosslen/lfd/clef"
+
     "github.com/stretchr/testify/assert"
-    // "github.com/hosslen/lfd/clef"
 )
 
 var (
@@ -50,6 +51,8 @@ var (
     timesFilename = "../resource/10k-test-pkts.times"
     maxNumPkts = 10000
     pktNumInBinary int     // number of packets written into the binary file
+
+    maxWatchlistSize = uint32(512)
 )
 
 //to test if it compiles ...
@@ -269,8 +272,8 @@ func TestRLFDPerformanceAgainstBaseline(t *testing.T) {
 }
 
 //measure detection performance of the CLEF detector against the baseline detector
-/*
 func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
+
     //FP and FN
     falsePositives := 0
     falseNegatives := 0
@@ -287,7 +290,7 @@ func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
     eardet := eardet.NewConfigedEardetDtctr(ed_counter_num, alpha, beta_l, gamma_l, p)
     rlfd1 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
     rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
-    cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2)
+    cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2, t_l, gamma, beta, maxWatchlistSize)
     bd := baseline.NewBaselineDtctr(beta, gamma)
 
     //initialize packets
@@ -298,6 +301,7 @@ func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
     var pkt *caidaPkt
     var flowID complex128
     murmur3.ResetSeed()
+
     cd.SetCurrentTime(trace.packets[0].Duration)
     var resCD, resBD bool
     for i := 0; i < len(trace.packets); i++ {
@@ -348,11 +352,10 @@ func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
     fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
     fmt.Printf("Number of flows: %d\n", bd.NumFlows)
     fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
-    fmt.Printf("Number of flows detected by rlfd: %d\n", len(blackListRD))
+    fmt.Printf("Number of flows detected by clef: %d\n", len(blackListRD))
     fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
     fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
 }
-*/
 
 //count the hash collisions
 func TestForHashCollisions(t *testing.T) {

--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -681,6 +681,7 @@ func TestBaselineWithTraceMemoryLowDirect(t *testing.T) {
             pktTime, _ := time.ParseDuration(timesScanner.Text() + "s")
 
             pkt = convertToCaidaPkt(&TraceData{}, packet, pktTime)
+
             flowID = murmur3.Murmur3_32_caida(&pkt.Id)
             tic = time.Now()
             res = detector.Detect(flowID, pkt.Size, pkt.Duration)

--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -290,7 +290,7 @@ func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
     eardet := eardet.NewConfigedEardetDtctr(ed_counter_num, alpha, beta_l, gamma_l, p)
     rlfd1 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
     rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, time.Duration((2*7*gamma_h)/(1.5*gamma))*t_l)
-    cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2, t_l, gamma, beta, maxWatchlistSize)
+    cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2, gamma, beta, maxWatchlistSize)
     bd := baseline.NewBaselineDtctr(beta, gamma)
 
     //initialize packets

--- a/clef/clef.go
+++ b/clef/clef.go
@@ -70,7 +70,7 @@ func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr, gamm
 
     cd.watchlist = make(map[uint32](*leakyBucket))
     cd.maxWatchlistSize = maxWatchlistSize
-    cd.watchlistTimeout = rlfd1.Get_t_l()
+    cd.watchlistTimeout = rlfd1.Get_t_l() // TODO: think how to best set this value
 
     cd.blacklist = cuckoo.NewCuckoo()
 

--- a/clef/clef.go
+++ b/clef/clef.go
@@ -3,20 +3,20 @@ package clef
 import (
     "time"
 
-	"github.com/hosslen/lfd/eardet"
-	"github.com/hosslen/lfd/murmur3"
-	"github.com/hosslen/lfd/rlfd"
+    "github.com/hosslen/lfd/eardet"
+    "github.com/hosslen/lfd/murmur3"
+    "github.com/hosslen/lfd/rlfd"
 
-	"github.com/hosslen/lfd/cuckoo"
+    "github.com/hosslen/lfd/cuckoo"
 )
 
 type leakyBucket struct {
-	//moment in time when flow was inserted into watchlist
-	firstTimestamp time.Duration
-	//moment in time when last packet for this flow was received
-	lastTimestamp time.Duration
-	//how many bytes the bucket contains right now
-	count uint32
+    //moment in time when flow was inserted into watchlist
+    firstTimestamp time.Duration
+    //moment in time when last packet for this flow was received
+    lastTimestamp time.Duration
+    //how many bytes the bucket contains right now
+    count uint32
 }
 
 type pktTriple struct {
@@ -27,32 +27,32 @@ type pktTriple struct {
 
 type ClefDtctr struct {
 
-	//flow lists
-	watchlist map[uint32](*leakyBucket)
-	maxWatchlistSize uint32
-	blacklist *cuckoo.CuckooTable
+    //flow lists
+    watchlist map[uint32](*leakyBucket)
+    maxWatchlistSize uint32
+    blacklist *cuckoo.CuckooTable
 
-	//flow specification
-	beta float64
-	gamma float64
-	t_l time.Duration
+    //flow specification
+    beta float64
+    gamma float64
+    t_l time.Duration
 
-	//detectors
-	eardet *eardet.EardetDtctr
-	rlfd1 *rlfd.RlfdDtctr
-	rlfd2 *rlfd.RlfdDtctr
+    //detectors
+    eardet *eardet.EardetDtctr
+    rlfd1 *rlfd.RlfdDtctr
+    rlfd2 *rlfd.RlfdDtctr
 
-	//channels
-	packetsForEardet chan pktTriple
-	packetsForRlfd1 chan pktTriple
-	packetsForRlfd2 chan pktTriple
-	resultsEardet chan bool
-	resultsRlfd1 chan bool
-	resultsRlfd2 chan bool
+    //channels
+    packetsForEardet chan pktTriple
+    packetsForRlfd1 chan pktTriple
+    packetsForRlfd2 chan pktTriple
+    resultsEardet chan bool
+    resultsRlfd1 chan bool
+    resultsRlfd2 chan bool
 }
 
 func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr, t_l time.Duration, gamma, beta float64, maxWatchlistSize uint32) *ClefDtctr {
-	cd := &ClefDtctr{}
+    cd := &ClefDtctr{}
 
     //set detectors
     cd.eardet = eardet
@@ -68,19 +68,19 @@ func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr, t_l 
     cd.resultsRlfd1 = make(chan bool, 3)
     cd.resultsRlfd2 = make(chan bool, 3)
 
-	cd.watchlist = make(map[uint32](*leakyBucket))
-	cd.maxWatchlistSize = maxWatchlistSize
+    cd.watchlist = make(map[uint32](*leakyBucket))
+    cd.maxWatchlistSize = maxWatchlistSize
 
-	cd.blacklist = cuckoo.NewCuckoo()
+    cd.blacklist = cuckoo.NewCuckoo()
 
-	cd.t_l = t_l
-	cd.gamma = gamma
-	cd.beta = beta
+    cd.t_l = t_l
+    cd.gamma = gamma
+    cd.beta = beta
 
-	//start worker threads
-	go eardetWorker(cd.eardet, cd.packetsForEardet, cd.resultsEardet)
-	go rlfdWorker(cd.rlfd1, cd.packetsForRlfd1, cd.resultsRlfd1)
-	go rlfdWorker(cd.rlfd2, cd.packetsForRlfd2, cd.resultsRlfd2)
+    //start worker threads
+    go eardetWorker(cd.eardet, cd.packetsForEardet, cd.resultsEardet)
+    go rlfdWorker(cd.rlfd1, cd.packetsForRlfd1, cd.resultsRlfd1)
+    go rlfdWorker(cd.rlfd2, cd.packetsForRlfd2, cd.resultsRlfd2)
 
     return cd
 }
@@ -102,83 +102,83 @@ func (cd *ClefDtctr) SetCurrentTime(now time.Duration) {
 }
 
 func (cd *ClefDtctr) cleanupWatchlist(t time.Duration) {
-	for flowID, _ := range cd.watchlist {
-		if (t - cd.watchlist[flowID].firstTimestamp > cd.t_l) {
-			delete(cd.watchlist, flowID)
-		}
-	}
+    for flowID, _ := range cd.watchlist {
+        if (t - cd.watchlist[flowID].firstTimestamp > cd.t_l) {
+            delete(cd.watchlist, flowID)
+        }
+    }
 
 }
 
 
 func (cd *ClefDtctr) Detect(id *[16]byte, size uint32, t time.Duration) bool {
 
-	//calculate murmur3 hash
-	flowID := murmur3.Murmur3_32_caida(id)
+    //calculate murmur3 hash
+    flowID := murmur3.Murmur3_32_caida(id)
 
-	//check blacklist
-	if _, ok := cd.blacklist.LookUp(flowID); ok {
-		return true
-	}
+    //check blacklist
+    if _, ok := cd.blacklist.LookUp(flowID); ok {
+        return true
+    }
 
-	//create pktTriple
-	pkt := pktTriple{flowID, size, t}
+    //create pktTriple
+    pkt := pktTriple{flowID, size, t}
 
-	//check watchlist
-	flowBucket, ok := cd.watchlist[flowID]
+    //check watchlist
+    flowBucket, ok := cd.watchlist[flowID]
 
-	// If a flow is already in the watchlist, update its leaky bucket or purge it if expired
-	if ok {
-		if (t - flowBucket.firstTimestamp > cd.t_l) {
-			delete(cd.watchlist, flowID)
-		} else {
-			flowBucket.count += size
-			legitimateTraffic := uint32(float64(t-flowBucket.lastTimestamp) * cd.gamma)
-			if (flowBucket.count > legitimateTraffic){
-				flowBucket.count -= legitimateTraffic
-			} else {
-				flowBucket.count = 0
-			}
-			flowBucket.lastTimestamp = t
+    // If a flow is already in the watchlist, update its leaky bucket or purge it if expired
+    if ok {
+        if (t - flowBucket.firstTimestamp > cd.t_l) {
+            delete(cd.watchlist, flowID)
+        } else {
+            flowBucket.count += size
+            legitimateTraffic := uint32(float64(t-flowBucket.lastTimestamp) * cd.gamma)
+            if (flowBucket.count > legitimateTraffic){
+                flowBucket.count -= legitimateTraffic
+            } else {
+                flowBucket.count = 0
+            }
+            flowBucket.lastTimestamp = t
 
-			if (float64(flowBucket.count) > cd.beta) {
-				cd.blacklist.Insert(flowID, 0)
-				return true
-			}
-		}
-	}
+            if (float64(flowBucket.count) > cd.beta) {
+                cd.blacklist.Insert(flowID, 0)
+                return true
+            }
+        }
+    }
 
-	//stuff pkt in channels
-	cd.packetsForEardet <- pkt
-	cd.packetsForRlfd1 <- pkt
-	cd.packetsForRlfd2 <- pkt
+    //stuff pkt in channels
+    cd.packetsForEardet <- pkt
+    cd.packetsForRlfd1 <- pkt
+    cd.packetsForRlfd2 <- pkt
 
-	//get results
-	detected := false
-	for i := 0; i < 3; i++ {
-		select {
-			case r := <-cd.resultsEardet:
-				detected = detected || r
-			case r := <-cd.resultsRlfd1:
-				detected = detected || r
-			case r := <-cd.resultsRlfd2:
-				detected = detected || r
-		}
-	}
+    //get results
+    detected := false
+    for i := 0; i < 3; i++ {
+        select {
+            case r := <-cd.resultsEardet:
+                detected = detected || r
+            case r := <-cd.resultsRlfd1:
+                detected = detected || r
+            case r := <-cd.resultsRlfd2:
+                detected = detected || r
+        }
+    }
 
-	// Insert flow into watchlist
-	if detected && !ok {
-		// If we have to insert a flow into the watchlist and there is too little space,
-		//  let's see if there are expired flow entries in the watchlist
-		if (uint32(len(cd.watchlist)) > cd.maxWatchlistSize) {
-			cd.cleanupWatchlist(t)
-		}
-		// TODO: what if still not enough space?
-		cd.watchlist[flowID] = &leakyBucket{firstTimestamp: t}
-	}
+    // Insert flow into watchlist
+    if detected && !ok {
+        // If we have to insert a flow into the watchlist and there is too little space,
+        //  let's see if there are expired flow entries in the watchlist
+        if (uint32(len(cd.watchlist)) > cd.maxWatchlistSize) {
+            cd.cleanupWatchlist(t)
+        }
+        // TODO: what if still not enough space?
+        cd.watchlist[flowID] = &leakyBucket{firstTimestamp: t}
+    }
 
-	return false
-	
+    return false
+    
 }
 
 func eardetWorker(dtctr *eardet.EardetDtctr, packets <-chan pktTriple, results chan<- bool) {

--- a/clef/clef.go
+++ b/clef/clef.go
@@ -3,10 +3,21 @@ package clef
 import (
     "time"
 
-    "github.com/hosslen/lfd/eardet"
-    "github.com/hosslen/lfd/murmur3"
-    "github.com/hosslen/lfd/rlfd"
+	"github.com/hosslen/lfd/eardet"
+	"github.com/hosslen/lfd/murmur3"
+	"github.com/hosslen/lfd/rlfd"
+
+	"github.com/hosslen/lfd/cuckoo"
 )
+
+type leakyBucket struct {
+	//moment in time when flow was inserted into watchlist
+	firstTimestamp time.Duration
+	//moment in time when last packet for this flow was received
+	lastTimestamp time.Duration
+	//how many bytes the bucket contains right now
+	count uint32
+}
 
 type pktTriple struct {
     flowID uint32
@@ -15,22 +26,33 @@ type pktTriple struct {
 }
 
 type ClefDtctr struct {
-    //detectors
-    eardet *eardet.EardetDtctr
-    rlfd1 *rlfd.RlfdDtctr
-    rlfd2 *rlfd.RlfdDtctr
 
-    //channels
-    packetsForEardet chan pktTriple
-    packetsForRlfd1 chan pktTriple
-    packetsForRlfd2 chan pktTriple
-    resultsEardet chan bool
-    resultsRlfd1 chan bool
-    resultsRlfd2 chan bool
+	//flow lists
+	watchlist map[uint32](*leakyBucket)
+	maxWatchlistSize uint32
+	blacklist *cuckoo.CuckooTable
+
+	//flow specification
+	beta float64
+	gamma float64
+	t_l time.Duration
+
+	//detectors
+	eardet *eardet.EardetDtctr
+	rlfd1 *rlfd.RlfdDtctr
+	rlfd2 *rlfd.RlfdDtctr
+
+	//channels
+	packetsForEardet chan pktTriple
+	packetsForRlfd1 chan pktTriple
+	packetsForRlfd2 chan pktTriple
+	resultsEardet chan bool
+	resultsRlfd1 chan bool
+	resultsRlfd2 chan bool
 }
 
-func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr) *ClefDtctr {
-    cd := &ClefDtctr{}
+func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr, t_l time.Duration, gamma, beta float64, maxWatchlistSize uint32) *ClefDtctr {
+	cd := &ClefDtctr{}
 
     //set detectors
     cd.eardet = eardet
@@ -46,10 +68,19 @@ func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr) *Cle
     cd.resultsRlfd1 = make(chan bool, 3)
     cd.resultsRlfd2 = make(chan bool, 3)
 
-    //start worker threads
-    go eardetWorker(cd.eardet, cd.packetsForEardet, cd.resultsEardet)
-    go rlfdWorker(cd.rlfd1, cd.packetsForRlfd1, cd.resultsRlfd1)
-    go rlfdWorker(cd.rlfd2, cd.packetsForRlfd2, cd.resultsRlfd2)
+	cd.watchlist = make(map[uint32](*leakyBucket))
+	cd.maxWatchlistSize = maxWatchlistSize
+
+	cd.blacklist = cuckoo.NewCuckoo()
+
+	cd.t_l = t_l
+	cd.gamma = gamma
+	cd.beta = beta
+
+	//start worker threads
+	go eardetWorker(cd.eardet, cd.packetsForEardet, cd.resultsEardet)
+	go rlfdWorker(cd.rlfd1, cd.packetsForRlfd1, cd.resultsRlfd1)
+	go rlfdWorker(cd.rlfd2, cd.packetsForRlfd2, cd.resultsRlfd2)
 
     return cd
 }
@@ -70,34 +101,84 @@ func (cd *ClefDtctr) SetCurrentTime(now time.Duration) {
     cd.rlfd2.SetCurrentTime(now)
 }
 
+func (cd *ClefDtctr) cleanupWatchlist(t time.Duration) {
+	for flowID, _ := range cd.watchlist {
+		if (t - cd.watchlist[flowID].firstTimestamp > cd.t_l) {
+			delete(cd.watchlist, flowID)
+		}
+	}
+
+}
+
 
 func (cd *ClefDtctr) Detect(id *[16]byte, size uint32, t time.Duration) bool {
-    //TODO: Change this
-    //calculate murmur3 hash
-    flowID := murmur3.Murmur3_32_caida(id)
 
-    //create pktTriple
-    pkt := pktTriple{flowID, size, t}
+	//calculate murmur3 hash
+	flowID := murmur3.Murmur3_32_caida(id)
 
-    //stuff pkt in channels
-    cd.packetsForEardet <- pkt
-    cd.packetsForRlfd1 <- pkt
-    cd.packetsForRlfd2 <- pkt
+	//check blacklist
+	if _, ok := cd.blacklist.LookUp(flowID); ok {
+		return true
+	}
 
-    //get results
-    detected := false
-    for i := 0; i < 3; i++ {
-        select {
-            case r := <-cd.resultsEardet:
-                detected = detected || r
-            case r := <-cd.resultsRlfd1:
-                detected = detected || r
-            case r := <-cd.resultsRlfd2:
-                detected = detected || r
-        }
-    }
+	//create pktTriple
+	pkt := pktTriple{flowID, size, t}
 
-    return detected
+	//check watchlist
+	flowBucket, ok := cd.watchlist[flowID]
+
+	// If a flow is already in the watchlist, update its leaky bucket or purge it if expired
+	if ok {
+		if (t - flowBucket.firstTimestamp > cd.t_l) {
+			delete(cd.watchlist, flowID)
+		} else {
+			flowBucket.count += size
+			legitimateTraffic := uint32(float64(t-flowBucket.lastTimestamp) * cd.gamma)
+			if (flowBucket.count > legitimateTraffic){
+				flowBucket.count -= legitimateTraffic
+			} else {
+				flowBucket.count = 0
+			}
+			flowBucket.lastTimestamp = t
+
+			if (float64(flowBucket.count) > cd.beta) {
+				cd.blacklist.Insert(flowID, 0)
+				return true
+			}
+		}
+	}
+
+	//stuff pkt in channels
+	cd.packetsForEardet <- pkt
+	cd.packetsForRlfd1 <- pkt
+	cd.packetsForRlfd2 <- pkt
+
+	//get results
+	detected := false
+	for i := 0; i < 3; i++ {
+		select {
+			case r := <-cd.resultsEardet:
+				detected = detected || r
+			case r := <-cd.resultsRlfd1:
+				detected = detected || r
+			case r := <-cd.resultsRlfd2:
+				detected = detected || r
+		}
+	}
+
+	// Insert flow into watchlist
+	if detected && !ok {
+		// If we have to insert a flow into the watchlist and there is too little space,
+		//  let's see if there are expired flow entries in the watchlist
+		if (uint32(len(cd.watchlist)) > cd.maxWatchlistSize) {
+			cd.cleanupWatchlist(t)
+		}
+		// TODO: what if still not enough space?
+		cd.watchlist[flowID] = &leakyBucket{firstTimestamp: t}
+	}
+
+	return false
+	
 }
 
 func eardetWorker(dtctr *eardet.EardetDtctr, packets <-chan pktTriple, results chan<- bool) {

--- a/cuckoo/cuckoo.go
+++ b/cuckoo/cuckoo.go
@@ -1,0 +1,216 @@
+// Copyright 2017 Nicolas Forster
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements a cuckoo hash table using two different hashes of the
+// key to find an appropriate place for the element to be inserted.
+// The maximum table size is 2^16 elements.
+
+package cuckoo
+
+import (
+	"crypto/rand"
+	"github.com/hosslen/lfd/murmur3"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"runtime"
+	"unsafe"
+	//"bitbucket/cuckoohash/murmur"
+)
+
+const (
+	maxLen      = 16
+	minIdxBytes = 10
+	maxLoadFact = 0.5
+)
+
+// The key has to be uint32. But one can adjust the value to whatever type one wants.
+type entry struct {
+	key   uint32
+	value uint32
+}
+
+type CuckooTable struct {
+	entries   []*entry
+	seed      uint32
+	idxBytes  uint32
+	nEntries  uint32
+	nRehashes uint32
+}
+
+// resetSeed() resets the current seed. Used during a rehash of the table.
+func (c *CuckooTable) resetSeed() {
+	s := make([]byte, 4)
+	_, err := rand.Read(s)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
+
+	c.seed = binary.LittleEndian.Uint32(s)
+}
+
+func NewCuckoo() *CuckooTable {
+	initLen := 1 << minIdxBytes
+	entries := make([]*entry, initLen)
+	c := &CuckooTable{
+		entries:  entries,
+		idxBytes: minIdxBytes,
+	}
+	c.resetSeed()
+
+	return c
+}
+
+// getHashedKeys() generates the two hashed keys. Important to note is that
+// only one hash is generated. This hash is then split up into the two
+// hashed key values used for inserting/finding an object.
+func (c *CuckooTable) getHashedKeys(key uint32) (uint32, uint32) {
+	keyBytes := (*[8]byte)(unsafe.Pointer(&key))
+	hash := murmur3.Murmur3_32(keyBytes)
+	h1 := hash >> (32 - c.idxBytes)
+	h2 := hash & uint32((1<<c.idxBytes)-1)
+	return h1, h2
+}
+
+// LookUp() looks an element up in the table.
+func (c *CuckooTable) LookUp(key uint32) (uint32, bool) {
+	h1, h2 := c.getHashedKeys(key)
+	if entry := c.entries[h1]; entry != nil && entry.key == key {
+		return entry.value, true
+	}
+
+	if entry := c.entries[h2]; entry != nil && entry.key == key {
+		return entry.value, true
+	}
+
+	return 0, false
+}
+
+// Insert() inserts an element at the appropriate position in the table.
+func (c *CuckooTable) Insert(key uint32, value uint32) bool {
+	if _, exists := c.LookUp(key); exists {
+		return false
+	}
+
+	h1, h2 := c.getHashedKeys(key)
+
+	newEntry := &entry{key, value}
+	index := h1
+	tLen := 1 << c.idxBytes
+
+	// reorder the elements in the table until all elements found a place,
+	// or tLen reordering steps have been done (to avoid an infinite loop).
+	for count := 0; count < tLen; count++ {
+		oldEntry := c.entries[index]
+		c.entries[index] = newEntry
+
+		if oldEntry == nil {
+			c.nEntries += 1
+			return true
+		}
+
+		h1, h2 = c.getHashedKeys(oldEntry.key)
+
+		if index == h1 {
+			index = h2
+		} else {
+			index = h1
+		}
+
+		newEntry = oldEntry
+	}
+
+	// If no stable table configuration can be found, first try to rehash the table
+	// if that does not help, grow the table.
+	if c.nRehashes < 3 {
+		c.rehash()
+	} else {
+		c.grow()
+	}
+
+	return c.Insert(newEntry.key, newEntry.value)
+}
+
+// Delete() deletes an element.
+func (c *CuckooTable) Delete(key uint32) {
+	h1, h2 := c.getHashedKeys(key)
+	if entry := c.entries[h1]; entry != nil && entry.key == key {
+		c.entries[h1] = nil
+		c.nEntries -= 1
+	}
+
+	if entry := c.entries[h2]; entry != nil && entry.key == key {
+		c.entries[h2] = nil
+		c.nEntries -= 1
+	}
+
+	// If the load factor of the table is too low, shrink the table.
+	if c.LoadFactor() < maxLoadFact/2 {
+		c.shrink()
+	}
+
+}
+
+func (c *CuckooTable) rehash() {
+	c.nEntries = 0
+	c.nRehashes += 1
+	c.reorganize()
+}
+
+func (c *CuckooTable) grow() {
+	c.idxBytes += 1
+	c.nEntries = 0
+	c.nRehashes = 0
+
+	if c.idxBytes > maxLen {
+		panic("Too many elements")
+	}
+
+	c.reorganize()
+}
+
+func (c *CuckooTable) shrink() {
+	if c.idxBytes <= minIdxBytes {
+		return
+	}
+	c.idxBytes -= 1
+	c.nEntries = 0
+	c.nRehashes = 0
+
+	c.reorganize()
+}
+
+func (c *CuckooTable) reorganize() {
+	tempTab := &CuckooTable{}
+	*tempTab = *c
+	c.resetSeed()
+
+	c.entries = make([]*entry, 1<<c.idxBytes)
+
+	for _, val := range tempTab.entries {
+		if val != nil {
+			c.Insert(val.key, val.value)
+		}
+	}
+
+	defer func() {
+		tempTab = nil
+		runtime.GC()
+	}()
+}
+
+func (c *CuckooTable) LoadFactor() float64 {
+	tLen := 1 << c.idxBytes
+	return float64(c.nEntries) / float64(tLen)
+}

--- a/cuckoo/cuckoo.go
+++ b/cuckoo/cuckoo.go
@@ -19,198 +19,198 @@
 package cuckoo
 
 import (
-	"crypto/rand"
-	"github.com/hosslen/lfd/murmur3"
-	"encoding/binary"
-	"fmt"
-	"os"
-	"runtime"
-	"unsafe"
-	//"bitbucket/cuckoohash/murmur"
+    "crypto/rand"
+    "github.com/hosslen/lfd/murmur3"
+    "encoding/binary"
+    "fmt"
+    "os"
+    "runtime"
+    "unsafe"
+    //"bitbucket/cuckoohash/murmur"
 )
 
 const (
-	maxLen      = 16
-	minIdxBytes = 10
-	maxLoadFact = 0.5
+    maxLen      = 16
+    minIdxBytes = 10
+    maxLoadFact = 0.5
 )
 
 // The key has to be uint32. But one can adjust the value to whatever type one wants.
 type entry struct {
-	key   uint32
-	value uint32
+    key   uint32
+    value uint32
 }
 
 type CuckooTable struct {
-	entries   []*entry
-	seed      uint32
-	idxBytes  uint32
-	nEntries  uint32
-	nRehashes uint32
+    entries   []*entry
+    seed      uint32
+    idxBytes  uint32
+    nEntries  uint32
+    nRehashes uint32
 }
 
 // resetSeed() resets the current seed. Used during a rehash of the table.
 func (c *CuckooTable) resetSeed() {
-	s := make([]byte, 4)
-	_, err := rand.Read(s)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-	}
+    s := make([]byte, 4)
+    _, err := rand.Read(s)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "%v\n", err)
+    }
 
-	c.seed = binary.LittleEndian.Uint32(s)
+    c.seed = binary.LittleEndian.Uint32(s)
 }
 
 func NewCuckoo() *CuckooTable {
-	initLen := 1 << minIdxBytes
-	entries := make([]*entry, initLen)
-	c := &CuckooTable{
-		entries:  entries,
-		idxBytes: minIdxBytes,
-	}
-	c.resetSeed()
+    initLen := 1 << minIdxBytes
+    entries := make([]*entry, initLen)
+    c := &CuckooTable{
+        entries:  entries,
+        idxBytes: minIdxBytes,
+    }
+    c.resetSeed()
 
-	return c
+    return c
 }
 
 // getHashedKeys() generates the two hashed keys. Important to note is that
 // only one hash is generated. This hash is then split up into the two
 // hashed key values used for inserting/finding an object.
 func (c *CuckooTable) getHashedKeys(key uint32) (uint32, uint32) {
-	keyBytes := (*[8]byte)(unsafe.Pointer(&key))
-	hash := murmur3.Murmur3_32(keyBytes)
-	h1 := hash >> (32 - c.idxBytes)
-	h2 := hash & uint32((1<<c.idxBytes)-1)
-	return h1, h2
+    keyBytes := (*[8]byte)(unsafe.Pointer(&key))
+    hash := murmur3.Murmur3_32(keyBytes)
+    h1 := hash >> (32 - c.idxBytes)
+    h2 := hash & uint32((1<<c.idxBytes)-1)
+    return h1, h2
 }
 
 // LookUp() looks an element up in the table.
 func (c *CuckooTable) LookUp(key uint32) (uint32, bool) {
-	h1, h2 := c.getHashedKeys(key)
-	if entry := c.entries[h1]; entry != nil && entry.key == key {
-		return entry.value, true
-	}
+    h1, h2 := c.getHashedKeys(key)
+    if entry := c.entries[h1]; entry != nil && entry.key == key {
+        return entry.value, true
+    }
 
-	if entry := c.entries[h2]; entry != nil && entry.key == key {
-		return entry.value, true
-	}
+    if entry := c.entries[h2]; entry != nil && entry.key == key {
+        return entry.value, true
+    }
 
-	return 0, false
+    return 0, false
 }
 
 // Insert() inserts an element at the appropriate position in the table.
 func (c *CuckooTable) Insert(key uint32, value uint32) bool {
-	if _, exists := c.LookUp(key); exists {
-		return false
-	}
+    if _, exists := c.LookUp(key); exists {
+        return false
+    }
 
-	h1, h2 := c.getHashedKeys(key)
+    h1, h2 := c.getHashedKeys(key)
 
-	newEntry := &entry{key, value}
-	index := h1
-	tLen := 1 << c.idxBytes
+    newEntry := &entry{key, value}
+    index := h1
+    tLen := 1 << c.idxBytes
 
-	// reorder the elements in the table until all elements found a place,
-	// or tLen reordering steps have been done (to avoid an infinite loop).
-	for count := 0; count < tLen; count++ {
-		oldEntry := c.entries[index]
-		c.entries[index] = newEntry
+    // reorder the elements in the table until all elements found a place,
+    // or tLen reordering steps have been done (to avoid an infinite loop).
+    for count := 0; count < tLen; count++ {
+        oldEntry := c.entries[index]
+        c.entries[index] = newEntry
 
-		if oldEntry == nil {
-			c.nEntries += 1
-			return true
-		}
+        if oldEntry == nil {
+            c.nEntries += 1
+            return true
+        }
 
-		h1, h2 = c.getHashedKeys(oldEntry.key)
+        h1, h2 = c.getHashedKeys(oldEntry.key)
 
-		if index == h1 {
-			index = h2
-		} else {
-			index = h1
-		}
+        if index == h1 {
+            index = h2
+        } else {
+            index = h1
+        }
 
-		newEntry = oldEntry
-	}
+        newEntry = oldEntry
+    }
 
-	// If no stable table configuration can be found, first try to rehash the table
-	// if that does not help, grow the table.
-	if c.nRehashes < 3 {
-		c.rehash()
-	} else {
-		c.grow()
-	}
+    // If no stable table configuration can be found, first try to rehash the table
+    // if that does not help, grow the table.
+    if c.nRehashes < 3 {
+        c.rehash()
+    } else {
+        c.grow()
+    }
 
-	return c.Insert(newEntry.key, newEntry.value)
+    return c.Insert(newEntry.key, newEntry.value)
 }
 
 // Delete() deletes an element.
 func (c *CuckooTable) Delete(key uint32) {
-	h1, h2 := c.getHashedKeys(key)
-	if entry := c.entries[h1]; entry != nil && entry.key == key {
-		c.entries[h1] = nil
-		c.nEntries -= 1
-	}
+    h1, h2 := c.getHashedKeys(key)
+    if entry := c.entries[h1]; entry != nil && entry.key == key {
+        c.entries[h1] = nil
+        c.nEntries -= 1
+    }
 
-	if entry := c.entries[h2]; entry != nil && entry.key == key {
-		c.entries[h2] = nil
-		c.nEntries -= 1
-	}
+    if entry := c.entries[h2]; entry != nil && entry.key == key {
+        c.entries[h2] = nil
+        c.nEntries -= 1
+    }
 
-	// If the load factor of the table is too low, shrink the table.
-	if c.LoadFactor() < maxLoadFact/2 {
-		c.shrink()
-	}
+    // If the load factor of the table is too low, shrink the table.
+    if c.LoadFactor() < maxLoadFact/2 {
+        c.shrink()
+    }
 
 }
 
 func (c *CuckooTable) rehash() {
-	c.nEntries = 0
-	c.nRehashes += 1
-	c.reorganize()
+    c.nEntries = 0
+    c.nRehashes += 1
+    c.reorganize()
 }
 
 func (c *CuckooTable) grow() {
-	c.idxBytes += 1
-	c.nEntries = 0
-	c.nRehashes = 0
+    c.idxBytes += 1
+    c.nEntries = 0
+    c.nRehashes = 0
 
-	if c.idxBytes > maxLen {
-		panic("Too many elements")
-	}
+    if c.idxBytes > maxLen {
+        panic("Too many elements")
+    }
 
-	c.reorganize()
+    c.reorganize()
 }
 
 func (c *CuckooTable) shrink() {
-	if c.idxBytes <= minIdxBytes {
-		return
-	}
-	c.idxBytes -= 1
-	c.nEntries = 0
-	c.nRehashes = 0
+    if c.idxBytes <= minIdxBytes {
+        return
+    }
+    c.idxBytes -= 1
+    c.nEntries = 0
+    c.nRehashes = 0
 
-	c.reorganize()
+    c.reorganize()
 }
 
 func (c *CuckooTable) reorganize() {
-	tempTab := &CuckooTable{}
-	*tempTab = *c
-	c.resetSeed()
+    tempTab := &CuckooTable{}
+    *tempTab = *c
+    c.resetSeed()
 
-	c.entries = make([]*entry, 1<<c.idxBytes)
+    c.entries = make([]*entry, 1<<c.idxBytes)
 
-	for _, val := range tempTab.entries {
-		if val != nil {
-			c.Insert(val.key, val.value)
-		}
-	}
+    for _, val := range tempTab.entries {
+        if val != nil {
+            c.Insert(val.key, val.value)
+        }
+    }
 
-	defer func() {
-		tempTab = nil
-		runtime.GC()
-	}()
+    defer func() {
+        tempTab = nil
+        runtime.GC()
+    }()
 }
 
 func (c *CuckooTable) LoadFactor() float64 {
-	tLen := 1 << c.idxBytes
-	return float64(c.nEntries) / float64(tLen)
+    tLen := 1 << c.idxBytes
+    return float64(c.nEntries) / float64(tLen)
 }

--- a/cuckoo/cuckoo_test.go
+++ b/cuckoo/cuckoo_test.go
@@ -1,0 +1,168 @@
+// Copyright 2017 Nicolas Forster
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cuckoo
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"testing"
+)
+
+var nOfItems = 1 << 15
+
+var (
+	keys      []uint32
+	values    []uint32
+	keyValMap map[uint32]uint32
+)
+
+var (
+	mapBytes uint64
+	mBench   map[uint32]uint32
+	cBench   CuckooTable
+)
+
+func readAlloc() uint64 {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return ms.Alloc
+}
+
+func init() {
+	keys = make([]uint32, nOfItems)
+	values = make([]uint32, nOfItems)
+
+	runtime.GC()
+	before := readAlloc()
+
+	keyValMap = make(map[uint32]uint32)
+	for i := 0; i < nOfItems; i++ {
+		k := rand.Uint32()
+		v := rand.Uint32()
+		keyValMap[k] = v
+		keys[i] = k
+		values[i] = v
+	}
+
+	after := readAlloc()
+	mapBytes = after - before
+}
+
+func TestInsertAndSearch(t *testing.T) {
+	c := NewCuckoo()
+
+	for key, value := range keyValMap {
+		c.Insert(key, value)
+	}
+
+	for key, value := range keyValMap {
+		elem, ok := c.LookUp(key)
+
+		if !ok || elem != value {
+			t.Error("search failed")
+		}
+	}
+}
+
+func TestDelete(t *testing.T) {
+	c := NewCuckoo()
+
+	for i := 0; i < 2000; i++ {
+		c.Insert(keys[i], values[i])
+	}
+
+	for i := 0; i < 2000; i++ {
+		c.Delete(keys[i])
+	}
+
+	for i := 0; i < 2000; i++ {
+		_, ok := c.LookUp(keys[i])
+
+		if ok {
+			t.Error("Delete failed.")
+		}
+	}
+}
+
+func TestMemory(t *testing.T) {
+	runtime.GC()
+	before := readAlloc()
+	c := NewCuckoo()
+
+	for key, value := range keyValMap {
+		c.Insert(key, value)
+	}
+
+	after := readAlloc()
+	cBytes := after - before
+
+	fmt.Print("MEMTEST")
+	t.Log("Built-in map mem usage (MiB):", float64(mapBytes)/float64(1<<20))
+	t.Log("Cuckoo hash mem usage (MiB):", float64(cBytes)/float64(1<<20))
+	t.Log("Cuckoo hash LoadFactor:", c.LoadFactor())
+}
+
+func BenchmarkCuckooTable_Insert(b *testing.B) {
+	cBench = *NewCuckoo()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cBench.Insert(keys[i%nOfItems], values[i%nOfItems])
+	}
+}
+
+func BenchmarkCuckooTable_LookUp(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cBench.LookUp(keys[i%nOfItems])
+	}
+}
+
+func BenchmarkCuckooTable_Delete(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cBench.Delete(keys[i%nOfItems])
+	}
+}
+
+func BenchmarkMapInsert(b *testing.B) {
+	mBench = make(map[uint32]uint32)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		key := keys[i%nOfItems]
+		value := values[i%nOfItems]
+		mBench[key] = value
+	}
+}
+
+func BenchmarkMapSearch(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = mBench[keys[i%nOfItems]]
+	}
+}
+
+func BenchmarkMapDelete(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		delete(mBench, keys[i%nOfItems])
+	}
+}

--- a/cuckoo/cuckoo_test.go
+++ b/cuckoo/cuckoo_test.go
@@ -15,154 +15,154 @@
 package cuckoo
 
 import (
-	"fmt"
-	"math/rand"
-	"runtime"
-	"testing"
+    "fmt"
+    "math/rand"
+    "runtime"
+    "testing"
 )
 
 var nOfItems = 1 << 15
 
 var (
-	keys      []uint32
-	values    []uint32
-	keyValMap map[uint32]uint32
+    keys      []uint32
+    values    []uint32
+    keyValMap map[uint32]uint32
 )
 
 var (
-	mapBytes uint64
-	mBench   map[uint32]uint32
-	cBench   CuckooTable
+    mapBytes uint64
+    mBench   map[uint32]uint32
+    cBench   CuckooTable
 )
 
 func readAlloc() uint64 {
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
-	return ms.Alloc
+    var ms runtime.MemStats
+    runtime.ReadMemStats(&ms)
+    return ms.Alloc
 }
 
 func init() {
-	keys = make([]uint32, nOfItems)
-	values = make([]uint32, nOfItems)
+    keys = make([]uint32, nOfItems)
+    values = make([]uint32, nOfItems)
 
-	runtime.GC()
-	before := readAlloc()
+    runtime.GC()
+    before := readAlloc()
 
-	keyValMap = make(map[uint32]uint32)
-	for i := 0; i < nOfItems; i++ {
-		k := rand.Uint32()
-		v := rand.Uint32()
-		keyValMap[k] = v
-		keys[i] = k
-		values[i] = v
-	}
+    keyValMap = make(map[uint32]uint32)
+    for i := 0; i < nOfItems; i++ {
+        k := rand.Uint32()
+        v := rand.Uint32()
+        keyValMap[k] = v
+        keys[i] = k
+        values[i] = v
+    }
 
-	after := readAlloc()
-	mapBytes = after - before
+    after := readAlloc()
+    mapBytes = after - before
 }
 
 func TestInsertAndSearch(t *testing.T) {
-	c := NewCuckoo()
+    c := NewCuckoo()
 
-	for key, value := range keyValMap {
-		c.Insert(key, value)
-	}
+    for key, value := range keyValMap {
+        c.Insert(key, value)
+    }
 
-	for key, value := range keyValMap {
-		elem, ok := c.LookUp(key)
+    for key, value := range keyValMap {
+        elem, ok := c.LookUp(key)
 
-		if !ok || elem != value {
-			t.Error("search failed")
-		}
-	}
+        if !ok || elem != value {
+            t.Error("search failed")
+        }
+    }
 }
 
 func TestDelete(t *testing.T) {
-	c := NewCuckoo()
+    c := NewCuckoo()
 
-	for i := 0; i < 2000; i++ {
-		c.Insert(keys[i], values[i])
-	}
+    for i := 0; i < 2000; i++ {
+        c.Insert(keys[i], values[i])
+    }
 
-	for i := 0; i < 2000; i++ {
-		c.Delete(keys[i])
-	}
+    for i := 0; i < 2000; i++ {
+        c.Delete(keys[i])
+    }
 
-	for i := 0; i < 2000; i++ {
-		_, ok := c.LookUp(keys[i])
+    for i := 0; i < 2000; i++ {
+        _, ok := c.LookUp(keys[i])
 
-		if ok {
-			t.Error("Delete failed.")
-		}
-	}
+        if ok {
+            t.Error("Delete failed.")
+        }
+    }
 }
 
 func TestMemory(t *testing.T) {
-	runtime.GC()
-	before := readAlloc()
-	c := NewCuckoo()
+    runtime.GC()
+    before := readAlloc()
+    c := NewCuckoo()
 
-	for key, value := range keyValMap {
-		c.Insert(key, value)
-	}
+    for key, value := range keyValMap {
+        c.Insert(key, value)
+    }
 
-	after := readAlloc()
-	cBytes := after - before
+    after := readAlloc()
+    cBytes := after - before
 
-	fmt.Print("MEMTEST")
-	t.Log("Built-in map mem usage (MiB):", float64(mapBytes)/float64(1<<20))
-	t.Log("Cuckoo hash mem usage (MiB):", float64(cBytes)/float64(1<<20))
-	t.Log("Cuckoo hash LoadFactor:", c.LoadFactor())
+    fmt.Print("MEMTEST")
+    t.Log("Built-in map mem usage (MiB):", float64(mapBytes)/float64(1<<20))
+    t.Log("Cuckoo hash mem usage (MiB):", float64(cBytes)/float64(1<<20))
+    t.Log("Cuckoo hash LoadFactor:", c.LoadFactor())
 }
 
 func BenchmarkCuckooTable_Insert(b *testing.B) {
-	cBench = *NewCuckoo()
-	b.ResetTimer()
+    cBench = *NewCuckoo()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		cBench.Insert(keys[i%nOfItems], values[i%nOfItems])
-	}
+    for i := 0; i < b.N; i++ {
+        cBench.Insert(keys[i%nOfItems], values[i%nOfItems])
+    }
 }
 
 func BenchmarkCuckooTable_LookUp(b *testing.B) {
-	b.ResetTimer()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		cBench.LookUp(keys[i%nOfItems])
-	}
+    for i := 0; i < b.N; i++ {
+        cBench.LookUp(keys[i%nOfItems])
+    }
 }
 
 func BenchmarkCuckooTable_Delete(b *testing.B) {
-	b.ResetTimer()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		cBench.Delete(keys[i%nOfItems])
-	}
+    for i := 0; i < b.N; i++ {
+        cBench.Delete(keys[i%nOfItems])
+    }
 }
 
 func BenchmarkMapInsert(b *testing.B) {
-	mBench = make(map[uint32]uint32)
-	b.ResetTimer()
+    mBench = make(map[uint32]uint32)
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		key := keys[i%nOfItems]
-		value := values[i%nOfItems]
-		mBench[key] = value
-	}
+    for i := 0; i < b.N; i++ {
+        key := keys[i%nOfItems]
+        value := values[i%nOfItems]
+        mBench[key] = value
+    }
 }
 
 func BenchmarkMapSearch(b *testing.B) {
-	b.ResetTimer()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		_, _ = mBench[keys[i%nOfItems]]
-	}
+    for i := 0; i < b.N; i++ {
+        _, _ = mBench[keys[i%nOfItems]]
+    }
 }
 
 func BenchmarkMapDelete(b *testing.B) {
-	b.ResetTimer()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		delete(mBench, keys[i%nOfItems])
-	}
+    for i := 0; i < b.N; i++ {
+        delete(mBench, keys[i%nOfItems])
+    }
 }

--- a/eardet/eardet.go
+++ b/eardet/eardet.go
@@ -18,10 +18,10 @@ package eardet
 import (
     // "fmt"
     "time"
+    "math"
 )
 
 //TODO:
-//Take care of carry-over
 //Change the way we find the new minimum
 
 const (
@@ -67,6 +67,9 @@ type EardetDtctr struct {
 
     //nanoseconds passed since start of interval
     currentTime time.Duration
+
+    //carry-over
+    co float64
 }
 
 //constructors
@@ -160,12 +163,13 @@ func (ed *EardetDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool 
     if (ed.currentTime < t) {
         //advance currentTime
         oldTime := ed.currentTime
-        //TODO: deal with the carry
         ed.currentTime = t + time.Duration(float64(size)/ed.linkCap)
         
         //calculate virtual traffic size
-        //TODO: deal with the carry
-        virtualTrafficSize := uint32(float64(t - oldTime)*ed.linkCap) + 1
+        virtualTrafficSizeRaw := float64(t - oldTime)*ed.linkCap
+        virtualTrafficSize := round(virtualTrafficSizeRaw + ed.co)
+        ed.co += virtualTrafficSizeRaw - float64(virtualTrafficSize)
+
         if virtualTrafficSize > ed.maxValue * ed.numCounters {
             ed.floor = ed.maxValue
             ed.threshold = ed.floor + ed.beta_th
@@ -185,6 +189,7 @@ func (ed *EardetDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool 
 
     //insert packet
     return ed.processPkt(flowID, size)
+    
 }
 
 //add the packet to counters
@@ -324,6 +329,14 @@ func min(a, b uint32) uint32 {
         return a
     }
     return b
+}
+
+func round(val float64) uint32 {
+    if (val - float64(uint32(val)) < 0.5) {
+        return uint32(math.Floor(val))
+    } else {
+        return uint32(math.Ceil(val))
+    }
 }
 
 

--- a/eardet/eardet.go
+++ b/eardet/eardet.go
@@ -189,7 +189,7 @@ func (ed *EardetDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool 
 
     //insert packet
     return ed.processPkt(flowID, size)
-    
+
 }
 
 //add the packet to counters

--- a/rlfd/rlfd.go
+++ b/rlfd/rlfd.go
@@ -106,6 +106,7 @@ func (rd *RlfdDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool {
         //are we on the lowest level?
         if rd.level == d - 1 {
             //do cuckoo hashing
+            // TODO: check if cuckoo hashing from cuckoo package can be used here
             var alt bool
             altIndex := (flowID & 0x38) >> 3
             if (c.flowID == flowID && c.reset == rd.reset) {

--- a/rlfd/rlfd.go
+++ b/rlfd/rlfd.go
@@ -156,5 +156,8 @@ func (rd *RlfdDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool {
     return false
 }
 
-
+// Getter method for t_l
+func (rd *RlfdDtctr) Get_t_l() time.Duration {
+    return rd.t_l
+}
 


### PR DESCRIPTION
This pull request contains various extensions to the Large Flow Detector:

**1. Carry-over**
As mentioned in @hosslen's report on p. 20, the implementation of the carry-over in the EARDet detector was still missing. This carry-over (as described in the EARDet paper, section 3.3) enables the implementation of counters as integers with a limited bias.

**2. AES hashing**
Instead of using the Murmur3 hash, @perrig suggested to use AES for hashing if it is fast enough. Although the implementation in ```aeshash/``` uses low-level AES-NI¸it takes considerably more time than the Murmur3 hash, as displayed in the benchmark below. On the other hand, we also get 128 bits out of it. _What are your opinions about whether the additional time consumption is justified?_
```
Average time per operation for Murmur3: 9.06ns 
Average time per operation for AESHasher: 17.71ns  
PASS
ok      github.com/hosslen/lfd/aeshash  1.859s 
```

**3. Watchlist in CLEF detector**
As I discussed with @perrig, the CLEF detector should not immediately report a detected flow, but instead insert it into a _watchlist_ of flows that are monitored more closely during another time t_l (temporary solution: simple leaky bucket). The watchlist is implemented as the standard Go hashtable and integrated into the CLEF detector. To specify a leaky bucket descriptor, I needed to add gamma/beta fields.

**4. Blacklist in CLEF detector**
I also integrated a blacklist into the CLEF detector, for which I used the Cuckoo table implemented and provided by Nicolas Forster (see under `cuckoo/`).

Please provide me with feedback both on design decisions and the code changes.

Best regards,
Simon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lfd/8)
<!-- Reviewable:end -->
