### PR TITLE
Convert all tab indentations to 4-spaces indentations

### DIFF
--- a/baseline/baseline.go
+++ b/baseline/baseline.go
@@ -1,70 +1,70 @@
 package baseline
 
 import (
-	"time"
+    "time"
 )
 
 type leakyBucket struct {
-	//moment in time when last packet for this flow was received
-	timestamp time.Duration
-	//how many bytes the bucket contains right now
-	count float64
+    //moment in time when last packet for this flow was received
+    timestamp time.Duration
+    //how many bytes the bucket contains right now
+    count float64
 }
 
 type BaselineDtctr struct {
-	//rate in B/ns at which a leaky bucket empties
-	gamma float64
-	//constant in equation TH(t) = gamma*t + beta
-	beta float64
-	//for testing
-	NumFlows int
-	//map that maps flowIDs to leakyBuckets
-	buckets map[uint32](*leakyBucket)
+    //rate in B/ns at which a leaky bucket empties
+    gamma float64
+    //constant in equation TH(t) = gamma*t + beta
+    beta float64
+    //for testing
+    NumFlows int
+    //map that maps flowIDs to leakyBuckets
+    buckets map[uint32](*leakyBucket)
 }
 
 //constructs a BaselineDtctr and returns a pointer to it
 func NewBaselineDtctr(beta, gamma float64) *BaselineDtctr {
-	bd := &BaselineDtctr{}
+    bd := &BaselineDtctr{}
 
-	//initialize buckets
-	bd.buckets = make(map[uint32](*leakyBucket), 797557)
+    //initialize buckets
+    bd.buckets = make(map[uint32](*leakyBucket), 797557)
 
-	//set parameters: TH(t) = gamma*t + beta 
-	bd.gamma = gamma
-	bd.beta = beta
+    //set parameters: TH(t) = gamma*t + beta 
+    bd.gamma = gamma
+    bd.beta = beta
 
-	return bd
+    return bd
 }
 
 //method that detects large flows, returns true if a packet violates the threshold function TH(t) = gamma*t + beta
 func (bd *BaselineDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool {
 
-	//get the right bucket and initialize it if it isn't already
-	bucket := bd.buckets[flowID]
-	if bucket == nil {
-		bucket = &leakyBucket{}
-		bd.buckets[flowID] = bucket
-		bd.NumFlows++
-	} else {
-		//if the bucket is not empty, decrement it according to the time passed since adding the last packet
-		temp := float64(t - bucket.timestamp)*bd.gamma
-		if bucket.count > temp {
-			bucket.count -= temp
-		} else {
-			bucket.count = 0.0
-		}
-	}
+    //get the right bucket and initialize it if it isn't already
+    bucket := bd.buckets[flowID]
+    if bucket == nil {
+        bucket = &leakyBucket{}
+        bd.buckets[flowID] = bucket
+        bd.NumFlows++
+    } else {
+        //if the bucket is not empty, decrement it according to the time passed since adding the last packet
+        temp := float64(t - bucket.timestamp)*bd.gamma
+        if bucket.count > temp {
+            bucket.count -= temp
+        } else {
+            bucket.count = 0.0
+        }
+    }
 
-	//increment bucket and set timestamp
-	bucket.count += float64(size)
-	bucket.timestamp = t
+    //increment bucket and set timestamp
+    bucket.count += float64(size)
+    bucket.timestamp = t
 
-	//check if the bucket overflows
-	if bucket.count > bd.beta {
-		return true;
-	}
+    //check if the bucket overflows
+    if bucket.count > bd.beta {
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 

--- a/baseline/baseline_test.go
+++ b/baseline/baseline_test.go
@@ -1,51 +1,51 @@
 package baseline
 
 import (
-	// "fmt"
-	"testing"
-	"time"
+    // "fmt"
+    "testing"
+    "time"
 )
 
 func insertPacket(t *testing.T, bd *BaselineDtctr, flowID uint32, size uint32, timestamp time.Duration) bool {
-	res := bd.Detect(flowID, size, timestamp)
+    res := bd.Detect(flowID, size, timestamp)
 
-	b := bd.buckets[flowID]
-	if b == nil {
-		t.Errorf("Detect: Packet(%d, %d, %d) not correctly inserted, corresponding bucket is nil.\n",
-			flowID, size, timestamp)
-	}
+    b := bd.buckets[flowID]
+    if b == nil {
+        t.Errorf("Detect: Packet(%d, %d, %d) not correctly inserted, corresponding bucket is nil.\n",
+            flowID, size, timestamp)
+    }
 
-	if b.count < float64(size)  || b.timestamp != timestamp {
-		t.Errorf("Detect: Packet(%d, %d, %d) not correctly inserted, b.count=%f, b.timestamp=%d.\n",
-			flowID, size, timestamp, b.count, b.timestamp)
-	}
-	return res
+    if b.count < float64(size)  || b.timestamp != timestamp {
+        t.Errorf("Detect: Packet(%d, %d, %d) not correctly inserted, b.count=%f, b.timestamp=%d.\n",
+            flowID, size, timestamp, b.count, b.timestamp)
+    }
+    return res
 }
 
 //insert a packet and test that it is present in the map
 func TestDetectBasicInsert(t *testing.T) {
-	detector := NewBaselineDtctr(1000.0, 5.0)
-	insertPacket(t, detector, 0, 100, 0)
+    detector := NewBaselineDtctr(1000.0, 5.0)
+    insertPacket(t, detector, 0, 100, 0)
 }
 
 //insert two packets for the same flowID and test that count is properly decremented/ incremented
 func TestDetectMultiInsert(t *testing.T) {
-	detector := NewBaselineDtctr(1000.0, 5.0)
-	insertPacket(t, detector, 0, 100, 0)
-	insertPacket(t, detector, 0, 200, 1)
-	b := detector.buckets[0]
-	if b.count != 295.0 {
-		t.Errorf("Detect: Packet(0, 200, 1) not correctly inserted, b.count=%f, b.timestamp=%d.\n",
-			b.count, b.timestamp)
-	}
+    detector := NewBaselineDtctr(1000.0, 5.0)
+    insertPacket(t, detector, 0, 100, 0)
+    insertPacket(t, detector, 0, 200, 1)
+    b := detector.buckets[0]
+    if b.count != 295.0 {
+        t.Errorf("Detect: Packet(0, 200, 1) not correctly inserted, b.count=%f, b.timestamp=%d.\n",
+            b.count, b.timestamp)
+    }
 }
 
 //insert a packet that triggers detection
 func TestDetectDetection(t *testing.T) {
-	detector := NewBaselineDtctr(1000.0, 5.0)
-	if res := insertPacket(t, detector, 1, 2000, 0); !res {
-		t.Errorf("Detect: Packet(1, 2000, 0) is not detected, should be.")
-	}
+    detector := NewBaselineDtctr(1000.0, 5.0)
+    if res := insertPacket(t, detector, 1, 2000, 0); !res {
+        t.Errorf("Detect: Packet(1, 2000, 0) is not detected, should be.")
+    }
 }
 
 

--- a/caida/caida.go
+++ b/caida/caida.go
@@ -2,18 +2,18 @@
 package caida
 
 import (
-	"encoding/binary"
-	"fmt"
-	"os"
-	"time"
+    "encoding/binary"
+    "fmt"
+    "os"
+    "time"
     "bufio"
 
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
-	"github.com/google/gopacket/pcap"
+    "github.com/google/gopacket"
+    "github.com/google/gopacket/layers"
+    "github.com/google/gopacket/pcap"
 
-	"github.com/hosslen/lfd/eardet"
-	"github.com/hosslen/lfd/murmur3"
+    "github.com/hosslen/lfd/eardet"
+    "github.com/hosslen/lfd/murmur3"
 )
 
 type TraceData struct {
@@ -29,10 +29,10 @@ type packetHandler func(packet gopacket.Packet, pktTime time.Duration) bool
 
 //encapsulates the information of one "packet" of the caida trace file
 type caidaPkt struct {
-	Duration time.Duration
-	//SrcIP (4 bytes)| DstIP (4 bytes)| Protocol (1 byte)| PortNumSrc (2 bytes)| PortNumDst (2 bytes) | 0 (3 bytes)
-	Id [16]byte
-	Size uint32
+    Duration time.Duration
+    //SrcIP (4 bytes)| DstIP (4 bytes)| Protocol (1 byte)| PortNumSrc (2 bytes)| PortNumDst (2 bytes) | 0 (3 bytes)
+    Id [16]byte
+    Size uint32
 }
 
 // Create a TraceData instance
@@ -49,10 +49,10 @@ func newTraceData(maxNumPkts int) *TraceData {
 
 //prints out the counters
 func printCounters(trace *TraceData) {
-	fmt.Printf("Total number of packets: %d\n", trace.packetCounter)
-	fmt.Printf("Total number of errors: %d\n", trace.errCounter)
-	fmt.Printf("Number of TCP over IPv4 packets: %d\n", trace.tcpCounter)
-	fmt.Printf("Number of UDP over IPv4 packets: %d\n", trace.udpCounter)
+    fmt.Printf("Total number of packets: %d\n", trace.packetCounter)
+    fmt.Printf("Total number of errors: %d\n", trace.errCounter)
+    fmt.Printf("Number of TCP over IPv4 packets: %d\n", trace.tcpCounter)
+    fmt.Printf("Number of UDP over IPv4 packets: %d\n", trace.udpCounter)
 }
 
 //loops over all packets in the pcap file
@@ -63,22 +63,22 @@ func loopOverPCAPFile(
     pcapHandle, pcapErr := pcap.OpenOffline(pcapFilename);
     timesHandle, timesErr := os.Open(timesFilename);
 
-	if pcapErr != nil {
-		fmt.Printf("Failed to open pcap file: %v\n", pcapErr)
-		os.Exit(1)
-	} else if timesErr != nil {
+    if pcapErr != nil {
+        fmt.Printf("Failed to open pcap file: %v\n", pcapErr)
+        os.Exit(1)
+    } else if timesErr != nil {
         fmt.Printf("Failed to open times file: %v\n", timesErr)
         os.Exit(1)
     } else {
-		var decoder gopacket.Decoder
-		if pcapHandle.LinkType() == 12 {
-			decoder = layers.LayerTypeIPv4
-		} else {
-			decoder = pcapHandle.LinkType()
-		}
-		packetSource := gopacket.NewPacketSource(pcapHandle, decoder)
+        var decoder gopacket.Decoder
+        if pcapHandle.LinkType() == 12 {
+            decoder = layers.LayerTypeIPv4
+        } else {
+            decoder = pcapHandle.LinkType()
+        }
+        packetSource := gopacket.NewPacketSource(pcapHandle, decoder)
         timesScanner := bufio.NewScanner(timesHandle)
-		for packet := range packetSource.Packets() {
+        for packet := range packetSource.Packets() {
             if !timesScanner.Scan() {
                 // no time stamp to read
                 fmt.Printf("Wrong trace files: timestamps are less" +
@@ -88,9 +88,9 @@ func loopOverPCAPFile(
             // timestamp with precision of nanosecond
             pktTime, _ := time.ParseDuration(timesScanner.Text() + "s")
             if !myHandler(packet, pktTime) {break}
-		}
+        }
         timesHandle.Close()
-	}
+    }
 }
 
 //converts a gopacket.Packet into a caidaPkt
@@ -98,58 +98,58 @@ func convertToCaidaPkt(
         trace *TraceData,
         packet gopacket.Packet,
         pktTime time.Duration) *caidaPkt {
-	pkt := &caidaPkt{}
-	captureInfo := &packet.Metadata().CaptureInfo
+    pkt := &caidaPkt{}
+    captureInfo := &packet.Metadata().CaptureInfo
     // pkt.Duration = captureInfo.Timestamp.Sub(time.Unix(0, 0))
     pkt.Duration = pktTime
-	pkt.Size = uint32(captureInfo.Length)
+    pkt.Size = uint32(captureInfo.Length)
 
-	if ipLayer := packet.Layer(layers.LayerTypeIPv4); ipLayer != nil {
-		ip, _ := ipLayer.(*layers.IPv4)
-		//ip.SrcIP []byte (4 bytes)
-		copy(pkt.Id[:4], ip.SrcIP[:4])
-		//ip.DstIP []byte (4 bytes)
-		copy(pkt.Id[4:8], ip.DstIP[:4])
-		//ip.Protocol uint8 which is an alias for byte
-		pkt.Id[8] = byte(ip.Protocol)
-	}
+    if ipLayer := packet.Layer(layers.LayerTypeIPv4); ipLayer != nil {
+        ip, _ := ipLayer.(*layers.IPv4)
+        //ip.SrcIP []byte (4 bytes)
+        copy(pkt.Id[:4], ip.SrcIP[:4])
+        //ip.DstIP []byte (4 bytes)
+        copy(pkt.Id[4:8], ip.DstIP[:4])
+        //ip.Protocol uint8 which is an alias for byte
+        pkt.Id[8] = byte(ip.Protocol)
+    }
 
-	if tcpLayer := packet.Layer(layers.LayerTypeTCP); tcpLayer != nil {
-		tcp, _ := tcpLayer.(*layers.TCP)
-		// tcp.SrcPort uint16
-		pkt.Id[9] = byte(tcp.SrcPort >> 8)
-		pkt.Id[10] = byte(tcp.SrcPort)
-		// tcp.DstPort uint16
-		pkt.Id[11] = byte(tcp.DstPort >> 8)
-		pkt.Id[12] = byte(tcp.DstPort)
-		trace.tcpCounter++
-	}
+    if tcpLayer := packet.Layer(layers.LayerTypeTCP); tcpLayer != nil {
+        tcp, _ := tcpLayer.(*layers.TCP)
+        // tcp.SrcPort uint16
+        pkt.Id[9] = byte(tcp.SrcPort >> 8)
+        pkt.Id[10] = byte(tcp.SrcPort)
+        // tcp.DstPort uint16
+        pkt.Id[11] = byte(tcp.DstPort >> 8)
+        pkt.Id[12] = byte(tcp.DstPort)
+        trace.tcpCounter++
+    }
 
-	if udpLayer := packet.Layer(layers.LayerTypeUDP); udpLayer != nil {
-		udp, _ := udpLayer.(*layers.UDP)
-		pkt.Id[9] = byte(udp.SrcPort >> 8)
-		pkt.Id[10] = byte(udp.SrcPort)
-		// tcp.DstPort uint16
-		pkt.Id[11] = byte(udp.DstPort >> 8)
-		pkt.Id[12] = byte(udp.DstPort)
-		trace.udpCounter++
-	}
+    if udpLayer := packet.Layer(layers.LayerTypeUDP); udpLayer != nil {
+        udp, _ := udpLayer.(*layers.UDP)
+        pkt.Id[9] = byte(udp.SrcPort >> 8)
+        pkt.Id[10] = byte(udp.SrcPort)
+        // tcp.DstPort uint16
+        pkt.Id[11] = byte(udp.DstPort >> 8)
+        pkt.Id[12] = byte(udp.DstPort)
+        trace.udpCounter++
+    }
 
-	//note that this is about 0.04% of all packets of this trace
-	if err := packet.ErrorLayer(); err != nil {
-		trace.errCounter++
-		// fmt.Printf("Error decoding some part of the packet: %v\n", err)
-	}
-	// fmt.Println(pkt)
+    //note that this is about 0.04% of all packets of this trace
+    if err := packet.ErrorLayer(); err != nil {
+        trace.errCounter++
+        // fmt.Printf("Error decoding some part of the packet: %v\n", err)
+    }
+    // fmt.Println(pkt)
 
-	return pkt
+    return pkt
 }
 
 //loades the caida trace file into packets
 func loadPCAPFile(
         pcapFilename string, timesFilename string, maxNumPkts int) *TraceData{
     trace = newTraceData(maxNumPkts)
-	loopOverPCAPFile(
+    loopOverPCAPFile(
         pcapFilename,
         timesFilename,
         func(packet gopacket.Packet, pktTime time.Duration) bool {
@@ -165,8 +165,8 @@ func loadPCAPFile(
             return true   
         })
 
-	trace.packetsInitialized = true
-	printCounters(trace)
+    trace.packetsInitialized = true
+    printCounters(trace)
 
     return trace
 }
@@ -174,50 +174,50 @@ func loadPCAPFile(
 //parses the caida packet trace and writes the output to a binary file
 func writeParsedTraceToBinary(
         pcapFilename string, timesFilename string) int {
-	//open file
-	f, err := os.Create("temp.dat")
-	if err != nil {
-		fmt.Printf("os.Create failed: %v\n", err)
-		os.Exit(1)
-	}
-	defer f.Close()
+    //open file
+    f, err := os.Create("temp.dat")
+    if err != nil {
+        fmt.Printf("os.Create failed: %v\n", err)
+        os.Exit(1)
+    }
+    defer f.Close()
 
     trace := newTraceData(0) // no need to store packets here
-	//loop over trace
-	loopOverPCAPFile(
+    //loop over trace
+    loopOverPCAPFile(
         pcapFilename,
         timesFilename,
         func(packet gopacket.Packet, pktTime time.Duration) bool {
-			pkt := convertToCaidaPkt(trace, packet, pktTime)
-			//write to binary file
-			err = binary.Write(f, binary.LittleEndian, pkt)
-			if err != nil {
-				fmt.Printf("binary.Write failed: %v\n", err)
-				os.Exit(1)
-			}
-			if trace.packetCounter < 10 {
-				fmt.Println(pkt)
-			}
-			trace.packetCounter++
+            pkt := convertToCaidaPkt(trace, packet, pktTime)
+            //write to binary file
+            err = binary.Write(f, binary.LittleEndian, pkt)
+            if err != nil {
+                fmt.Printf("binary.Write failed: %v\n", err)
+                os.Exit(1)
+            }
+            if trace.packetCounter < 10 {
+                fmt.Println(pkt)
+            }
+            trace.packetCounter++
 
             // can read and write the next packet
             return true
-		})
+        })
 
-	printCounters(trace)
+    printCounters(trace)
     return trace.packetCounter
-	// //rewind file
-	// f.Seek(0, 0)
+    // //rewind file
+    // f.Seek(0, 0)
 
-	// //test read
-	// pkt2 := &caidaPkt{}
-	// for i := 0; i < 10; i++ {
-	// 	err = binary.Read(f, binary.LittleEndian, pkt2)
-	// 	if err != nil {
-	// 		fmt.Println("binary.Read failed:", err)
-	// 	}
-	// 	fmt.Println(pkt2)
-	// }
+    // //test read
+    // pkt2 := &caidaPkt{}
+    // for i := 0; i < 10; i++ {
+    //  err = binary.Read(f, binary.LittleEndian, pkt2)
+    //  if err != nil {
+    //      fmt.Println("binary.Read failed:", err)
+    //  }
+    //  fmt.Println(pkt2)
+    // }
 }
 
 
@@ -226,60 +226,60 @@ func writeParsedTraceToBinary(
 func test() {
     // TODO: What is this function for???
 
-	var totalProcTime time.Duration
-	var tic time.Time
-	//10Gbps = 1.25B/ns
-	detector := eardet.NewEardetDtctr(128, 500, 1000, 1.25)
-	var flowID uint32
-	pkt := &caidaPkt{}
-	var set bool
-	var temp time.Duration
-	var max time.Duration = 0
-	var min time.Duration = 9223372036854775807
-	murmur3.ResetSeed()
+    var totalProcTime time.Duration
+    var tic time.Time
+    //10Gbps = 1.25B/ns
+    detector := eardet.NewEardetDtctr(128, 500, 1000, 1.25)
+    var flowID uint32
+    pkt := &caidaPkt{}
+    var set bool
+    var temp time.Duration
+    var max time.Duration = 0
+    var min time.Duration = 9223372036854775807
+    murmur3.ResetSeed()
 
-	//open file
-	f, err := os.Open("temp.dat")
-	if err != nil {
-		fmt.Println("os.Open failed:", err)
-		os.Exit(1)
-	}
-	defer f.Close()
+    //open file
+    f, err := os.Open("temp.dat")
+    if err != nil {
+        fmt.Println("os.Open failed:", err)
+        os.Exit(1)
+    }
+    defer f.Close()
 
     //TODO: temporarily put this variable here
     var numPkts = 1000
-	for i := 0; i < numPkts; i++ {
-		err = binary.Read(f, binary.LittleEndian, pkt)
-		if err != nil {
-			fmt.Println("binary.Read failed:", err)
-			os.Exit(1)
-		}
+    for i := 0; i < numPkts; i++ {
+        err = binary.Read(f, binary.LittleEndian, pkt)
+        if err != nil {
+            fmt.Println("binary.Read failed:", err)
+            os.Exit(1)
+        }
 
-		//for testing
-		// if i < 10 {
-		// 	fmt.Println(pkt)
-		// } else {
-		// 	break
-		// }
+        //for testing
+        // if i < 10 {
+        //  fmt.Println(pkt)
+        // } else {
+        //  break
+        // }
 
-		if !set {
-			detector.SetCurrentTime(pkt.Duration)
-			set = true
-		}
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		tic = time.Now()
-		// res2 = detector.Detect(flowID, pkt.Size, pkt.Duration)
+        if !set {
+            detector.SetCurrentTime(pkt.Duration)
+            set = true
+        }
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        tic = time.Now()
+        // res2 = detector.Detect(flowID, pkt.Size, pkt.Duration)
         detector.Detect(flowID, pkt.Size, pkt.Duration) 
-		temp = time.Since(tic)
-		totalProcTime += temp
-		if temp > max {
-			max = temp
-		} else if temp < min {
-			min = temp
-		}
-	}
-	fmt.Printf("Average time spend processing: %f ns.\n", float64(totalProcTime)/float64(numPkts))
-	fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
+        temp = time.Since(tic)
+        totalProcTime += temp
+        if temp > max {
+            max = temp
+        } else if temp < min {
+            min = temp
+        }
+    }
+    fmt.Printf("Average time spend processing: %f ns.\n", float64(totalProcTime)/float64(numPkts))
+    fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
 }
 
 

--- a/caida/caida_test.go
+++ b/caida/caida_test.go
@@ -1,48 +1,48 @@
 package caida
 
 import (
-	"encoding/binary"
-	"fmt"
-	"os"
-	"bufio"
-	"testing"
-	"time"
-	// "unsafe"
+    "encoding/binary"
+    "fmt"
+    "os"
+    "bufio"
+    "testing"
+    "time"
+    // "unsafe"
 
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
-	"github.com/google/gopacket/pcap"
+    "github.com/google/gopacket"
+    "github.com/google/gopacket/layers"
+    "github.com/google/gopacket/pcap"
 
-	"github.com/hosslen/lfd/baseline"
-	"github.com/hosslen/lfd/eardet"
-	"github.com/hosslen/lfd/murmur3"
-	"github.com/hosslen/lfd/rlfd"
-	"github.com/stretchr/testify/assert"
-	// "github.com/hosslen/lfd/clef"
+    "github.com/hosslen/lfd/baseline"
+    "github.com/hosslen/lfd/eardet"
+    "github.com/hosslen/lfd/murmur3"
+    "github.com/hosslen/lfd/rlfd"
+    "github.com/stretchr/testify/assert"
+    // "github.com/hosslen/lfd/clef"
 )
 
 var (
-	//to prevent too much optimization
-	res bool
+    //to prevent too much optimization
+    res bool
 
-	//parameters for
-	//TH_l(t) = gamma_l*t + beta_l
-	//TH_h(t) = gamma_h*t + beta_h
-	//beta_th = ((beta_l + (gamma_l * (alpha + beta_l)) / (linkCapacity / (numOfCounters + 1) - gamma_l)) + 1;
-	//beta_h = alpha + 2*beta_th
-	//gamma_h > p / (n + 1) = p / 129
-	p = float64(1.25) //10Gbps = 1.25B/ns
+    //parameters for
+    //TH_l(t) = gamma_l*t + beta_l
+    //TH_h(t) = gamma_h*t + beta_h
+    //beta_th = ((beta_l + (gamma_l * (alpha + beta_l)) / (linkCapacity / (numOfCounters + 1) - gamma_l)) + 1;
+    //beta_h = alpha + 2*beta_th
+    //gamma_h > p / (n + 1) = p / 129
+    p = float64(1.25) //10Gbps = 1.25B/ns
     ed_counter_num = uint32(128)
     gamma_h = p / float64(ed_counter_num + 1)
-    gamma_l = float64(p / 1000)	// low-bandwidth threshold is flow spec
-    beta_l = uint32(3008)		// low-bandwidth threshold is flow spec
-	alpha = uint32(1504)
-	// beta_th = uint32(5000)
-	
-	// flow spec:
-	beta = float64(beta_l)
-	gamma = float64(gamma_l)
-	t_l = time.Duration(beta/gamma)
+    gamma_l = float64(p / 1000) // low-bandwidth threshold is flow spec
+    beta_l = uint32(3008)       // low-bandwidth threshold is flow spec
+    alpha = uint32(1504)
+    // beta_th = uint32(5000)
+    
+    // flow spec:
+    beta = float64(beta_l)
+    gamma = float64(gamma_l)
+    t_l = time.Duration(beta/gamma)
 
     // trace for testing
     trace *TraceData
@@ -54,7 +54,7 @@ var (
 
 //to test if it compiles ...
 func TestDoNothing(t *testing.T) {
-	fmt.Println("Do nothing ...")
+    fmt.Println("Do nothing ...")
 }
 
 //parses the trace file specified in caida.go and writes the caidaPkts to a binary file
@@ -66,363 +66,363 @@ func TestWriteParsedTraceToBinary(t *testing.T) {
 }
 
 func TestPacketTimestamp(t *testing.T) {
-	// load packets with nanosecond timestamps from timesFilename
-	if trace == nil {
+    // load packets with nanosecond timestamps from timesFilename
+    if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
 
     // load packets with microsecond timestamps from pcapFilename
     pcapHandle, pcapErr := pcap.OpenOffline(pcapFilename);
 
-	if pcapErr != nil {
-		fmt.Printf("Failed to open pcap file: %v\n", pcapErr)
-		os.Exit(1)
-	} else {
-		var decoder gopacket.Decoder
-		if pcapHandle.LinkType() == 12 {
-    			decoder = layers.LayerTypeIPv4
-		} else {
-    			decoder = pcapHandle.LinkType()
-		}
-		packetSource := gopacket.NewPacketSource(pcapHandle, decoder)
-		var count = 0
-		for packet := range packetSource.Packets() {
-			captureInfo := &packet.Metadata().CaptureInfo
-    		msTime := captureInfo.Timestamp.Sub(time.Unix(0, 0))
+    if pcapErr != nil {
+        fmt.Printf("Failed to open pcap file: %v\n", pcapErr)
+        os.Exit(1)
+    } else {
+        var decoder gopacket.Decoder
+        if pcapHandle.LinkType() == 12 {
+                decoder = layers.LayerTypeIPv4
+        } else {
+                decoder = pcapHandle.LinkType()
+        }
+        packetSource := gopacket.NewPacketSource(pcapHandle, decoder)
+        var count = 0
+        for packet := range packetSource.Packets() {
+            captureInfo := &packet.Metadata().CaptureInfo
+            msTime := captureInfo.Timestamp.Sub(time.Unix(0, 0))
 
-    		truncatedNanoTime :=
-    			trace.packets[count].Duration.Nanoseconds() / 1000
-    		microTime := msTime.Nanoseconds() / 1000
-    		// verify the timestamps from timesFilename is aligned with
-    		// those from pcapFilename
-    		assert.Equal(t, microTime, truncatedNanoTime)
-    		// fmt.Printf("%d | %d\n", microTime, truncatedNanoTime)
+            truncatedNanoTime :=
+                trace.packets[count].Duration.Nanoseconds() / 1000
+            microTime := msTime.Nanoseconds() / 1000
+            // verify the timestamps from timesFilename is aligned with
+            // those from pcapFilename
+            assert.Equal(t, microTime, truncatedNanoTime)
+            // fmt.Printf("%d | %d\n", microTime, truncatedNanoTime)
 
-			count++
-    		if count >= maxNumPkts {break}
-		}
-	}
+            count++
+            if count >= maxNumPkts {break}
+        }
+    }
 
 }
 
 //measure detection performance of the EARDet detector against the baseline detector
 func TestEARDetPerformanceAgainstBaseline(t *testing.T) {
-	//FP and FN
-	falsePositives := 0
-	falseNegatives := 0
+    //FP and FN
+    falsePositives := 0
+    falseNegatives := 0
 
-	//damage metric
-	overuseDamage := uint32(0)
-	falsePositiveDamage := uint32(0)
+    //damage metric
+    overuseDamage := uint32(0)
+    falsePositiveDamage := uint32(0)
 
-	//blacklists
-	blackListED := make(map[uint32]int)
-	blackListBD := make(map[uint32]int)
+    //blacklists
+    blackListED := make(map[uint32]int)
+    blackListBD := make(map[uint32]int)
 
-	//initialize detectors
-	ed := eardet.NewConfigedEardetDtctr(
-		ed_counter_num, alpha, beta_l, gamma_l, p)
-	bd := baseline.NewBaselineDtctr(beta, gamma)
+    //initialize detectors
+    ed := eardet.NewConfigedEardetDtctr(
+        ed_counter_num, alpha, beta_l, gamma_l, p)
+    bd := baseline.NewBaselineDtctr(beta, gamma)
 
-	//initialize packets
+    //initialize packets
     if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
 
-	var flowID uint32
-	var pkt *caidaPkt
-	murmur3.ResetSeed()
-	ed.SetCurrentTime(trace.packets[0].Duration)
-	var resED, resBD bool
-	for i := 0; i < len(trace.packets); i++ {
-		pkt = trace.packets[i]
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		if _, ok := blackListED[flowID]; !ok {
-			resED = ed.Detect(flowID, pkt.Size, pkt.Duration)
-		} else {
-			resED = true
-		}
-		if _, ok := blackListBD[flowID]; !ok {
-			resBD = bd.Detect(flowID, pkt.Size, pkt.Duration)
-		} else {
-			resBD = true
-		}
+    var flowID uint32
+    var pkt *caidaPkt
+    murmur3.ResetSeed()
+    ed.SetCurrentTime(trace.packets[0].Duration)
+    var resED, resBD bool
+    for i := 0; i < len(trace.packets); i++ {
+        pkt = trace.packets[i]
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        if _, ok := blackListED[flowID]; !ok {
+            resED = ed.Detect(flowID, pkt.Size, pkt.Duration)
+        } else {
+            resED = true
+        }
+        if _, ok := blackListBD[flowID]; !ok {
+            resBD = bd.Detect(flowID, pkt.Size, pkt.Duration)
+        } else {
+            resBD = true
+        }
 
-		//update blacklists
-		if resED {
-			blackListED[flowID]++
-		}
-		if resBD {
-			blackListBD[flowID]++
-		}
+        //update blacklists
+        if resED {
+            blackListED[flowID]++
+        }
+        if resBD {
+            blackListBD[flowID]++
+        }
 
-		//damage metric
-		if resBD && !resED {
-			overuseDamage += pkt.Size
-		} else if !resBD && resED {
-			falsePositiveDamage += pkt.Size
-		}
-	}
+        //damage metric
+        if resBD && !resED {
+            overuseDamage += pkt.Size
+        } else if !resBD && resED {
+            falsePositiveDamage += pkt.Size
+        }
+    }
 
-	//compare blacklists
-	for k, _ := range blackListED {
-		if _, ok := blackListBD[k]; !ok {
-			falsePositives++
-		} 
-	}
-	for k, _ := range blackListBD {
-		if _, ok := blackListED[k]; !ok {
-			falseNegatives++
-		} 
-	}
-	fmt.Printf("TestEARDetPerformanceAgainstBaseline:\n")
-	fmt.Printf("eardetDtctr: alpha=%d, gamma_l=%d, beta_l=%d, gamma_h=%d, beta_h=%d, beta_th=%d, p=%fB/ns\n",
-				ed.GetAlpha, ed.GetGamma_l, ed.GetBeta_l,
-				ed.GetGamma_h, ed.GetBeta_h, ed.GetBeta_th, p)
-	fmt.Printf("baselineDtctr: beta=%f, gamma=%f\n", beta, gamma)
-	fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
-	fmt.Printf("Number of flows: %d\n", bd.NumFlows)
-	fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
-	fmt.Printf("Number of flows detected by eardet: %d\n", len(blackListED))
-	fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
-	fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
+    //compare blacklists
+    for k, _ := range blackListED {
+        if _, ok := blackListBD[k]; !ok {
+            falsePositives++
+        } 
+    }
+    for k, _ := range blackListBD {
+        if _, ok := blackListED[k]; !ok {
+            falseNegatives++
+        } 
+    }
+    fmt.Printf("TestEARDetPerformanceAgainstBaseline:\n")
+    fmt.Printf("eardetDtctr: alpha=%d, gamma_l=%d, beta_l=%d, gamma_h=%d, beta_h=%d, beta_th=%d, p=%fB/ns\n",
+                ed.GetAlpha, ed.GetGamma_l, ed.GetBeta_l,
+                ed.GetGamma_h, ed.GetBeta_h, ed.GetBeta_th, p)
+    fmt.Printf("baselineDtctr: beta=%f, gamma=%f\n", beta, gamma)
+    fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
+    fmt.Printf("Number of flows: %d\n", bd.NumFlows)
+    fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
+    fmt.Printf("Number of flows detected by eardet: %d\n", len(blackListED))
+    fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
+    fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
 }
 
 //measure detection performance of the RLFD detector against the baseline detector
 func TestRLFDPerformanceAgainstBaseline(t *testing.T) {
-	//FP and FN
-	falsePositives := 0
-	falseNegatives := 0
+    //FP and FN
+    falsePositives := 0
+    falseNegatives := 0
 
-	//damage metric
-	overuseDamage := uint32(0)
-	falsePositiveDamage := uint32(0)
+    //damage metric
+    overuseDamage := uint32(0)
+    falsePositiveDamage := uint32(0)
 
-	//blacklists
-	blackListRD := make(map[uint32]int)
-	blackListBD := make(map[uint32]int)
+    //blacklists
+    blackListRD := make(map[uint32]int)
+    blackListBD := make(map[uint32]int)
 
-	//initialize detectors
-	rd := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
-	bd := baseline.NewBaselineDtctr(beta, gamma)
+    //initialize detectors
+    rd := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
+    bd := baseline.NewBaselineDtctr(beta, gamma)
 
-	//initialize packets
+    //initialize packets
     if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
 
-	var flowID uint32
-	var pkt *caidaPkt
-	murmur3.ResetSeed()
-	rd.SetCurrentTime(trace.packets[0].Duration)
-	var resRD, resBD bool
-	for i := 0; i < len(trace.packets); i++ {
-		pkt = trace.packets[i]
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		if _, ok := blackListRD[flowID]; !ok {
-			resRD = rd.Detect(flowID, pkt.Size, pkt.Duration)
-		} else {
-			resRD = true
-		}
-		if _, ok := blackListBD[flowID]; !ok {
-			resBD = bd.Detect(flowID, pkt.Size, pkt.Duration)
-		} else {
-			resBD = true
-		}
+    var flowID uint32
+    var pkt *caidaPkt
+    murmur3.ResetSeed()
+    rd.SetCurrentTime(trace.packets[0].Duration)
+    var resRD, resBD bool
+    for i := 0; i < len(trace.packets); i++ {
+        pkt = trace.packets[i]
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        if _, ok := blackListRD[flowID]; !ok {
+            resRD = rd.Detect(flowID, pkt.Size, pkt.Duration)
+        } else {
+            resRD = true
+        }
+        if _, ok := blackListBD[flowID]; !ok {
+            resBD = bd.Detect(flowID, pkt.Size, pkt.Duration)
+        } else {
+            resBD = true
+        }
 
-		//update blacklists
-		if resRD {
-			blackListRD[flowID]++
-		}
-		if resBD {
-			blackListBD[flowID]++
-		}
+        //update blacklists
+        if resRD {
+            blackListRD[flowID]++
+        }
+        if resBD {
+            blackListBD[flowID]++
+        }
 
-		//damage metric
-		if resBD && !resRD {
-			overuseDamage += pkt.Size
-		} else if !resBD && resRD {
-			falsePositiveDamage += pkt.Size
-		}
-	}
+        //damage metric
+        if resBD && !resRD {
+            overuseDamage += pkt.Size
+        } else if !resBD && resRD {
+            falsePositiveDamage += pkt.Size
+        }
+    }
 
-	//compare blacklists
-	for k, _ := range blackListRD {
-		if _, ok := blackListBD[k]; !ok {
-			falsePositives++
-		} 
-	}
-	for k, _ := range blackListBD {
-		if _, ok := blackListRD[k]; !ok {
-			falseNegatives++
-		} 
-	}
-	fmt.Printf("TestRLFDPerformanceAgainstBaseline:\n")
-	fmt.Printf("rlfdDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
-	fmt.Printf("baselineDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
-	fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
-	fmt.Printf("Number of flows: %d\n", bd.NumFlows)
-	fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
-	fmt.Printf("Number of flows detected by rlfd: %d\n", len(blackListRD))
-	fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
-	fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
+    //compare blacklists
+    for k, _ := range blackListRD {
+        if _, ok := blackListBD[k]; !ok {
+            falsePositives++
+        } 
+    }
+    for k, _ := range blackListBD {
+        if _, ok := blackListRD[k]; !ok {
+            falseNegatives++
+        } 
+    }
+    fmt.Printf("TestRLFDPerformanceAgainstBaseline:\n")
+    fmt.Printf("rlfdDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
+    fmt.Printf("baselineDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
+    fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
+    fmt.Printf("Number of flows: %d\n", bd.NumFlows)
+    fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
+    fmt.Printf("Number of flows detected by rlfd: %d\n", len(blackListRD))
+    fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
+    fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
 }
 
 //measure detection performance of the CLEF detector against the baseline detector
 /*
 func TestCLEFPerformanceAgainstBaseline(t *testing.T) {
-	//FP and FN
-	falsePositives := 0
-	falseNegatives := 0
+    //FP and FN
+    falsePositives := 0
+    falseNegatives := 0
 
-	//damage metric in Byte
-	overuseDamage := uint32(0)
-	falsePositiveDamage := uint32(0)
+    //damage metric in Byte
+    overuseDamage := uint32(0)
+    falsePositiveDamage := uint32(0)
 
-	//blacklists
-	blackListRD := make(map[complex128]int)
-	blackListBD := make(map[complex128]int)
+    //blacklists
+    blackListRD := make(map[complex128]int)
+    blackListBD := make(map[complex128]int)
 
-	//initialize detectors
-	eardet := eardet.NewConfigedEardetDtctr(ed_counter_num, alpha, beta_l, gamma_l, p)
-	rlfd1 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
-	rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
-	cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2)
-	bd := baseline.NewBaselineDtctr(beta, gamma)
+    //initialize detectors
+    eardet := eardet.NewConfigedEardetDtctr(ed_counter_num, alpha, beta_l, gamma_l, p)
+    rlfd1 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
+    rlfd2 := rlfd.NewRlfdDtctr(uint32(beta), gamma, t_l)
+    cd := clef.NewClefDtctr(eardet, rlfd1, rlfd2)
+    bd := baseline.NewBaselineDtctr(beta, gamma)
 
-	//initialize packets
+    //initialize packets
     if trace == nil {
         trace = loadPCAPFile(pcapFilename, maxNumPkts)
     }
 
-	var pkt *caidaPkt
-	var flowID complex128
+    var pkt *caidaPkt
+    var flowID complex128
     murmur3.ResetSeed()
-	cd.SetCurrentTime(trace.packets[0].Duration)
-	var resCD, resBD bool
-	for i := 0; i < len(trace.packets); i++ {
-		pkt = trace.packets[i]
-		flowID = *((*complex128) (unsafe.Pointer(&pkt.Id)))
-		if _, ok := blackListRD[flowID]; !ok {
-			resCD = cd.Detect(&pkt.Id, pkt.Size, pkt.Duration)
-		} else {
-			resCD = true
-		}
-		if _, ok := blackListBD[flowID]; !ok {
-			//TODO: Change this
-			resBD = bd.Detect(0, pkt.Size, pkt.Duration)
-		} else {
-			resBD = true
-		}
+    cd.SetCurrentTime(trace.packets[0].Duration)
+    var resCD, resBD bool
+    for i := 0; i < len(trace.packets); i++ {
+        pkt = trace.packets[i]
+        flowID = *((*complex128) (unsafe.Pointer(&pkt.Id)))
+        if _, ok := blackListRD[flowID]; !ok {
+            resCD = cd.Detect(&pkt.Id, pkt.Size, pkt.Duration)
+        } else {
+            resCD = true
+        }
+        if _, ok := blackListBD[flowID]; !ok {
+            //TODO: Change this
+            resBD = bd.Detect(0, pkt.Size, pkt.Duration)
+        } else {
+            resBD = true
+        }
 
-		//update blacklists
-		if resCD {
-			blackListRD[flowID]++
-		}
-		if resBD {
-			blackListBD[flowID]++
-		}
+        //update blacklists
+        if resCD {
+            blackListRD[flowID]++
+        }
+        if resBD {
+            blackListBD[flowID]++
+        }
 
-		//damage metric
-		if resBD && !resCD {
-			overuseDamage += pkt.Size
-		} else if !resBD && resCD {
-			falsePositiveDamage += pkt.Size
-		}
-	}
+        //damage metric
+        if resBD && !resCD {
+            overuseDamage += pkt.Size
+        } else if !resBD && resCD {
+            falsePositiveDamage += pkt.Size
+        }
+    }
 
-	//compare blacklists
-	for k, _ := range blackListRD {
-		if _, ok := blackListBD[k]; !ok {
-			falsePositives++
-		} 
-	}
-	for k, _ := range blackListBD {
-		if _, ok := blackListRD[k]; !ok {
-			falseNegatives++
-		} 
-	}
-	fmt.Printf("TestCLEFPerformanceAgainstBaseline:\n")
-	fmt.Printf("clefDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
-	fmt.Printf("baselineDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
-	fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
-	fmt.Printf("Number of flows: %d\n", bd.NumFlows)
-	fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
-	fmt.Printf("Number of flows detected by rlfd: %d\n", len(blackListRD))
-	fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
-	fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
+    //compare blacklists
+    for k, _ := range blackListRD {
+        if _, ok := blackListBD[k]; !ok {
+            falsePositives++
+        } 
+    }
+    for k, _ := range blackListBD {
+        if _, ok := blackListRD[k]; !ok {
+            falseNegatives++
+        } 
+    }
+    fmt.Printf("TestCLEFPerformanceAgainstBaseline:\n")
+    fmt.Printf("clefDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
+    fmt.Printf("baselineDtctr: beta=%fB, gamma=%fB/ns\n", beta, gamma)
+    fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
+    fmt.Printf("Number of flows: %d\n", bd.NumFlows)
+    fmt.Printf("Number of flows detected by baseline: %d\n", len(blackListBD))
+    fmt.Printf("Number of flows detected by rlfd: %d\n", len(blackListRD))
+    fmt.Printf("FP (flows): %d FN (flows): %d\n", falsePositives, falseNegatives)
+    fmt.Printf("overuseDamage: %dB, falsePositiveDamage: %dB\n", overuseDamage, falsePositiveDamage)
 }
 */
 
 //count the hash collisions
 func TestForHashCollisions(t *testing.T) {
-	//initialize packets
+    //initialize packets
     if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
 
-	myMap := make(map[uint32]([]string))
+    myMap := make(map[uint32]([]string))
 
-	var flowID uint32
-	var bucket []string
-	var pkt *caidaPkt
-	murmur3.ResetSeed()
-	for i := 0; i < len(trace.packets); i++ {
-		pkt = trace.packets[i]
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		bucket = myMap[flowID]
-		if bucket == nil {
-			bucket = make([]string, 0)
-			myMap[flowID] = bucket
-		}
-		//append if not equal
-		temp := string(pkt.Id[:])
-		b := false
-		for _, s := range bucket {
-			if s == temp {
-				b = true
-			}
-		}
-		if !b {
-			myMap[flowID] = append(bucket, temp)
-		}
-	}
+    var flowID uint32
+    var bucket []string
+    var pkt *caidaPkt
+    murmur3.ResetSeed()
+    for i := 0; i < len(trace.packets); i++ {
+        pkt = trace.packets[i]
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        bucket = myMap[flowID]
+        if bucket == nil {
+            bucket = make([]string, 0)
+            myMap[flowID] = bucket
+        }
+        //append if not equal
+        temp := string(pkt.Id[:])
+        b := false
+        for _, s := range bucket {
+            if s == temp {
+                b = true
+            }
+        }
+        if !b {
+            myMap[flowID] = append(bucket, temp)
+        }
+    }
 
-	colCounter := 0
-	for k, v := range myMap {
-		if len(v) > 1 {
-			fmt.Printf("%d: %d\n", k, len(v))
-			colCounter++
-		}
-	}
-	fmt.Printf("Collisions: %d\n", colCounter)
-	fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
+    colCounter := 0
+    for k, v := range myMap {
+        if len(v) > 1 {
+            fmt.Printf("%d: %d\n", k, len(v))
+            colCounter++
+        }
+    }
+    fmt.Printf("Collisions: %d\n", colCounter)
+    fmt.Printf("Seed for murmur3: %d\n", murmur3.GetSeed())
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 //////Benchmark EARDet and Baseline detector with binary file /////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 func BenchmarkEARDetWithTraceMemoryLowBinary(b *testing.B) {
-	//10Gbps = 1.25B/ns
-	detector := eardet.NewConfigedEardetDtctr(
-		ed_counter_num, alpha, beta_l, gamma_l, p)
-	var flowID uint32
-	pkt := &caidaPkt{}
-	var set bool
-	murmur3.ResetSeed()
+    //10Gbps = 1.25B/ns
+    detector := eardet.NewConfigedEardetDtctr(
+        ed_counter_num, alpha, beta_l, gamma_l, p)
+    var flowID uint32
+    pkt := &caidaPkt{}
+    var set bool
+    murmur3.ResetSeed()
 
-	//open file
-	f, err := os.Open("temp.dat")
-	if err != nil {
-		fmt.Println("os.Open failed:", err)
-	}
+    //open file
+    f, err := os.Open("temp.dat")
+    if err != nil {
+        fmt.Println("os.Open failed:", err)
+    }
     defer f.Close()
 
-	b.StopTimer()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err = binary.Read(f, binary.LittleEndian, pkt)
-		if err != nil {
+    b.StopTimer()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        err = binary.Read(f, binary.LittleEndian, pkt)
+        if err != nil {
             if err.Error() == "EOF" {
                 // if file is ended, rewind and performa again
                 f.Seek(0, 0)
@@ -431,44 +431,44 @@ func BenchmarkEARDetWithTraceMemoryLowBinary(b *testing.B) {
             } else {
                 fmt.Println("binary.Read failed:", err)
             }
-		}
-		//for testing
-		// if i < 10 {
-		// 	fmt.Println(pkt)
-		// } else {
-		// 	break
-		// }
+        }
+        //for testing
+        // if i < 10 {
+        //  fmt.Println(pkt)
+        // } else {
+        //  break
+        // }
 
-		if !set {
-			detector.SetCurrentTime(pkt.Duration)
-			set = true
-		}
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		b.StartTimer()
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-		b.StopTimer()
-	}
+        if !set {
+            detector.SetCurrentTime(pkt.Duration)
+            set = true
+        }
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        b.StartTimer()
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+        b.StopTimer()
+    }
 }
 
 func BenchmarkBaselineWithTraceMemoryLowBinary(b *testing.B) {
-	//10Gbps = 1.25B/ns
-	detector := baseline.NewBaselineDtctr(beta, gamma)
-	var flowID uint32
-	pkt := &caidaPkt{}
-	murmur3.ResetSeed()
+    //10Gbps = 1.25B/ns
+    detector := baseline.NewBaselineDtctr(beta, gamma)
+    var flowID uint32
+    pkt := &caidaPkt{}
+    murmur3.ResetSeed()
 
-	//open file
-	f, err := os.Open("temp.dat")
-	if err != nil {
-		fmt.Println("os.Open failed:", err)
-	}
-	defer f.Close()
+    //open file
+    f, err := os.Open("temp.dat")
+    if err != nil {
+        fmt.Println("os.Open failed:", err)
+    }
+    defer f.Close()
 
-	b.StopTimer()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err = binary.Read(f, binary.LittleEndian, pkt)
-		if err != nil {
+    b.StopTimer()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        err = binary.Read(f, binary.LittleEndian, pkt)
+        if err != nil {
             if err.Error() == "EOF" {
                 // if file is ended, rewind and performa again
                 f.Seek(0, 0)
@@ -477,119 +477,119 @@ func BenchmarkBaselineWithTraceMemoryLowBinary(b *testing.B) {
                 fmt.Println("binary.Read failed:", err)
             }
         }
-		//for testing
-		// if i < 10 {
-		// 	fmt.Println(pkt)
-		// } else {
-		// 	break
-		// }
+        //for testing
+        // if i < 10 {
+        //  fmt.Println(pkt)
+        // } else {
+        //  break
+        // }
 
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		b.StartTimer()
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-		b.StopTimer()
-	}
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        b.StartTimer()
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+        b.StopTimer()
+    }
 }
 
 func TestEARDetWithTraceMemoryLowBinary(t *testing.T) {
-	var totalProcTime time.Duration
-	var tic time.Time
-	//10Gbps = 1.25B/ns
-	detector := eardet.NewConfigedEardetDtctr(
-		ed_counter_num, alpha, beta_l, gamma_l, p)
-	var flowID uint32
-	pkt := &caidaPkt{}
-	var set bool
-	var temp time.Duration
-	var max time.Duration = 0
-	var min time.Duration = 9223372036854775807
-	murmur3.ResetSeed()
+    var totalProcTime time.Duration
+    var tic time.Time
+    //10Gbps = 1.25B/ns
+    detector := eardet.NewConfigedEardetDtctr(
+        ed_counter_num, alpha, beta_l, gamma_l, p)
+    var flowID uint32
+    pkt := &caidaPkt{}
+    var set bool
+    var temp time.Duration
+    var max time.Duration = 0
+    var min time.Duration = 9223372036854775807
+    murmur3.ResetSeed()
 
-	//open file
+    //open file
     // TODO: this test depends one the TestWriteParsedTraceToBinary
     // which is not good.
-	f, err := os.Open("temp.dat")
-	if err != nil {
-		fmt.Println("os.Open failed:", err)
-	}
-	defer f.Close()
+    f, err := os.Open("temp.dat")
+    if err != nil {
+        fmt.Println("os.Open failed:", err)
+    }
+    defer f.Close()
 
-	for i := 0; i < pktNumInBinary; i++ {
-		err = binary.Read(f, binary.LittleEndian, pkt)
-		if err != nil {
-			fmt.Println("binary.Read failed:", err)
-		}
-		//for testing
-		// if i < 10 {
-		// 	fmt.Println(pkt)
-		// } else {
-		// 	break
-		// }
+    for i := 0; i < pktNumInBinary; i++ {
+        err = binary.Read(f, binary.LittleEndian, pkt)
+        if err != nil {
+            fmt.Println("binary.Read failed:", err)
+        }
+        //for testing
+        // if i < 10 {
+        //  fmt.Println(pkt)
+        // } else {
+        //  break
+        // }
 
-		if !set {
-			detector.SetCurrentTime(pkt.Duration)
-			set = true
-		}
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		tic = time.Now()
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-		temp = time.Since(tic)
-		totalProcTime += temp
-		if temp > max {
-			max = temp
-		} else if temp < min {
-			min = temp
-		}
-	}
-	fmt.Printf("Average time spend processing: %f ns.\n",
+        if !set {
+            detector.SetCurrentTime(pkt.Duration)
+            set = true
+        }
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        tic = time.Now()
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+        temp = time.Since(tic)
+        totalProcTime += temp
+        if temp > max {
+            max = temp
+        } else if temp < min {
+            min = temp
+        }
+    }
+    fmt.Printf("Average time spend processing: %f ns.\n",
         float64(totalProcTime)/float64(pktNumInBinary))
-	fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
+    fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
 }
 
 func TestBaselinetWithTraceMemoryLowBinary(t *testing.T) {
     var totalProcTime time.Duration
-	var tic time.Time
-	//10Gbps = 1.25B/ns
-	detector := baseline.NewBaselineDtctr(beta, gamma)
-	var flowID uint32
-	pkt := &caidaPkt{}
-	var temp time.Duration
-	var max time.Duration = 0
-	var min time.Duration = 9223372036854775807
-	murmur3.ResetSeed()
+    var tic time.Time
+    //10Gbps = 1.25B/ns
+    detector := baseline.NewBaselineDtctr(beta, gamma)
+    var flowID uint32
+    pkt := &caidaPkt{}
+    var temp time.Duration
+    var max time.Duration = 0
+    var min time.Duration = 9223372036854775807
+    murmur3.ResetSeed()
 
-	//open file
-	f, err := os.Open("temp.dat")
-	if err != nil {
-		fmt.Println("os.Open failed:", err)
-	}
-	defer f.Close()
+    //open file
+    f, err := os.Open("temp.dat")
+    if err != nil {
+        fmt.Println("os.Open failed:", err)
+    }
+    defer f.Close()
 
-	for i := 0; i < pktNumInBinary; i++ {
-		err = binary.Read(f, binary.LittleEndian, pkt)
-		if err != nil {
-			fmt.Println("binary.Read failed:", err)
-		}
-		//for testing
-		// if i < 10 {
-		// 	fmt.Println(pkt)
-		// } else {
-		// 	break
-		// }
+    for i := 0; i < pktNumInBinary; i++ {
+        err = binary.Read(f, binary.LittleEndian, pkt)
+        if err != nil {
+            fmt.Println("binary.Read failed:", err)
+        }
+        //for testing
+        // if i < 10 {
+        //  fmt.Println(pkt)
+        // } else {
+        //  break
+        // }
 
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		tic = time.Now()
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-		temp = time.Since(tic)
-		totalProcTime += temp
-		if temp > max {
-			max = temp
-		} else if temp < min {
-			min = temp
-		}
-	}
-	fmt.Printf("Average time spent processing a packet: %f ns.\n", float64(totalProcTime)/float64(pktNumInBinary))
-	fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        tic = time.Now()
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+        temp = time.Since(tic)
+        totalProcTime += temp
+        if temp > max {
+            max = temp
+        } else if temp < min {
+            min = temp
+        }
+    }
+    fmt.Printf("Average time spent processing a packet: %f ns.\n", float64(totalProcTime)/float64(pktNumInBinary))
+    fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
 }
 
 
@@ -598,78 +598,78 @@ func TestBaselinetWithTraceMemoryLowBinary(t *testing.T) {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 func TestEARDetWithTraceMemoryLowDirect(t *testing.T) {
-	var totalProcTime time.Duration
-	var tic time.Time
-	//10Gbps = 1.25B/ns
-	detector := eardet.NewConfigedEardetDtctr(
-		ed_counter_num, alpha, beta_l, gamma_l, p)
-	var flowID uint32
-	var pkt *caidaPkt
-	var set bool
-	var temp time.Duration
-	var max time.Duration = 0
-	var min time.Duration = 9223372036854775807
-	murmur3.ResetSeed()
+    var totalProcTime time.Duration
+    var tic time.Time
+    //10Gbps = 1.25B/ns
+    detector := eardet.NewConfigedEardetDtctr(
+        ed_counter_num, alpha, beta_l, gamma_l, p)
+    var flowID uint32
+    var pkt *caidaPkt
+    var set bool
+    var temp time.Duration
+    var max time.Duration = 0
+    var min time.Duration = 9223372036854775807
+    murmur3.ResetSeed()
 
-	//test
-	loopOverPCAPFile(
-		pcapFilename,
-		timesFilename, 
-		func(packet gopacket.Packet, pktTime time.Duration) bool {
-			pkt = convertToCaidaPkt(&TraceData{}, packet, pktTime)
-			if !set {
-				detector.SetCurrentTime(pkt.Duration)
-				set = true
-			}
-			flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-			tic = time.Now()
-			res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-			temp = time.Since(tic)
-			totalProcTime += temp
-			if temp > max {
-				max = temp
-			} else if temp < min {
-				min = temp
-			}
+    //test
+    loopOverPCAPFile(
+        pcapFilename,
+        timesFilename, 
+        func(packet gopacket.Packet, pktTime time.Duration) bool {
+            pkt = convertToCaidaPkt(&TraceData{}, packet, pktTime)
+            if !set {
+                detector.SetCurrentTime(pkt.Duration)
+                set = true
+            }
+            flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+            tic = time.Now()
+            res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+            temp = time.Since(tic)
+            totalProcTime += temp
+            if temp > max {
+                max = temp
+            } else if temp < min {
+                min = temp
+            }
             return true
-		})
+        })
 
-	fmt.Printf("Average time spend processing: %f ns.\n", float64(totalProcTime)/float64(pktNumInBinary))
-	fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
+    fmt.Printf("Average time spend processing: %f ns.\n", float64(totalProcTime)/float64(pktNumInBinary))
+    fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
 }
 
 func TestBaselineWithTraceMemoryLowDirect(t *testing.T) {
-	var totalProcTime time.Duration
-	var tic time.Time
-	//10Gbps = 1.25B/ns
-	detector := baseline.NewBaselineDtctr(beta, gamma)
-	var flowID uint32
-	var pkt *caidaPkt
-	var temp time.Duration
-	var max time.Duration = 0
-	var min time.Duration = 9223372036854775807
-	murmur3.ResetSeed()
+    var totalProcTime time.Duration
+    var tic time.Time
+    //10Gbps = 1.25B/ns
+    detector := baseline.NewBaselineDtctr(beta, gamma)
+    var flowID uint32
+    var pkt *caidaPkt
+    var temp time.Duration
+    var max time.Duration = 0
+    var min time.Duration = 9223372036854775807
+    murmur3.ResetSeed()
 
-	pcapHandle, pcapErr := pcap.OpenOffline(pcapFilename);
+    pcapHandle, pcapErr := pcap.OpenOffline(pcapFilename);
     timesHandle, timesErr := os.Open(timesFilename);
 
-	if pcapErr != nil {
-		fmt.Printf("Failed to open pcap file: %v\n", pcapErr)
-		os.Exit(1)
-	} else if timesErr != nil {
+    if pcapErr != nil {
+        fmt.Printf("Failed to open pcap file: %v\n", pcapErr)
+        os.Exit(1)
+    } else if timesErr != nil {
         fmt.Printf("Failed to open times file: %v\n", timesErr)
         os.Exit(1)
     } else {
-		var decoder gopacket.Decoder
-		if pcapHandle.LinkType() == 12 {
-    			decoder = layers.LayerTypeIPv4
-		} else {
-    			decoder = pcapHandle.LinkType()
-		}
-		packetSource := gopacket.NewPacketSource(pcapHandle, decoder)
+        var decoder gopacket.Decoder
+        if pcapHandle.LinkType() == 12 {
+                decoder = layers.LayerTypeIPv4
+        } else {
+                decoder = pcapHandle.LinkType()
+        }
+        packetSource := gopacket.NewPacketSource(pcapHandle, decoder)
         timesScanner := bufio.NewScanner(timesHandle)
-		for packet := range packetSource.Packets() {
-			if !timesScanner.Scan() {
+        for packet := range packetSource.Packets() {
+            if !timesScanner.Scan() {
                 // no time stamp to read
                 fmt.Printf("Wrong trace files: timestamps are less" +
                     "than packets\n")
@@ -677,21 +677,21 @@ func TestBaselineWithTraceMemoryLowDirect(t *testing.T) {
             }
             pktTime, _ := time.ParseDuration(timesScanner.Text() + "s")
 
-			pkt = convertToCaidaPkt(&TraceData{}, packet, pktTime)
-			flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-			tic = time.Now()
-			res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-			temp = time.Since(tic)
-			totalProcTime += temp
-			if temp > max {
-				max = temp
-			} else if temp < min {
-				min = temp
-			}
-		}
-	}
-	fmt.Printf("Average time spend processing: %f ns.\n", float64(totalProcTime)/float64(pktNumInBinary))
-	fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
+            pkt = convertToCaidaPkt(&TraceData{}, packet, pktTime)
+            flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+            tic = time.Now()
+            res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+            temp = time.Since(tic)
+            totalProcTime += temp
+            if temp > max {
+                max = temp
+            } else if temp < min {
+                min = temp
+            }
+        }
+    }
+    fmt.Printf("Average time spend processing: %f ns.\n", float64(totalProcTime)/float64(pktNumInBinary))
+    fmt.Printf("Longest processing time: %d ns, shortest %d ns\n", max, min)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -699,71 +699,71 @@ func TestBaselineWithTraceMemoryLowDirect(t *testing.T) {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 func BenchmarkWithTraceLoadedBaseline(b *testing.B) {
-	//initialize packets
-	if trace == nil {
+    //initialize packets
+    if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
     //10Gbps = 1.25B/ns
-	detector := baseline.NewBaselineDtctr(beta, gamma)
-	var flowID uint32
-	var pkt *caidaPkt
-	murmur3.ResetSeed()
-	if (maxNumPkts < b.N) {
-		fmt.Printf("Warning: Not enough packets in the trace, benchmark might be inaccurate!")
-	}
+    detector := baseline.NewBaselineDtctr(beta, gamma)
+    var flowID uint32
+    var pkt *caidaPkt
+    murmur3.ResetSeed()
+    if (maxNumPkts < b.N) {
+        fmt.Printf("Warning: Not enough packets in the trace, benchmark might be inaccurate!")
+    }
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pkt = trace.packets[i % maxNumPkts]
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-	}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        pkt = trace.packets[i % maxNumPkts]
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+    }
 }
 
 func BenchmarkWithTraceLoadedEARDet(b *testing.B) {
-	//initialize packets
-	if trace == nil {
+    //initialize packets
+    if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
     //10Gbps = 1.25B/ns
-	detector := eardet.NewConfigedEardetDtctr(
-		ed_counter_num, alpha, beta_l, gamma_l, p)
-	var flowID uint32
-	var pkt *caidaPkt
-	murmur3.ResetSeed()
-	detector.SetCurrentTime(trace.packets[0].Duration)
-	if (maxNumPkts < b.N) {
-		fmt.Printf("Warning: Not enough packets in the trace, benchmark might be inaccurate!")
-	}
+    detector := eardet.NewConfigedEardetDtctr(
+        ed_counter_num, alpha, beta_l, gamma_l, p)
+    var flowID uint32
+    var pkt *caidaPkt
+    murmur3.ResetSeed()
+    detector.SetCurrentTime(trace.packets[0].Duration)
+    if (maxNumPkts < b.N) {
+        fmt.Printf("Warning: Not enough packets in the trace, benchmark might be inaccurate!")
+    }
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pkt = trace.packets[i % maxNumPkts]
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-	}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        pkt = trace.packets[i % maxNumPkts]
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+    }
 }
 
 func BenchmarkWithTraceLoadedRlfd(b *testing.B) {
-	//initialize packets
-	if trace == nil {
+    //initialize packets
+    if trace == nil {
         trace = loadPCAPFile(pcapFilename, timesFilename, maxNumPkts)
     }
-	detector := rlfd.NewRlfdDtctr(uint32(beta), gamma, 100)
-	var flowID uint32
-	var pkt *caidaPkt
-	murmur3.ResetSeed()
-	detector.SetCurrentTime(trace.packets[0].Duration)
-	if (maxNumPkts < b.N) {
-		fmt.Printf("Warning: Not enough packets in the trace, benchmark might be inaccurate!")
-	}
+    detector := rlfd.NewRlfdDtctr(uint32(beta), gamma, 100)
+    var flowID uint32
+    var pkt *caidaPkt
+    murmur3.ResetSeed()
+    detector.SetCurrentTime(trace.packets[0].Duration)
+    if (maxNumPkts < b.N) {
+        fmt.Printf("Warning: Not enough packets in the trace, benchmark might be inaccurate!")
+    }
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pkt = trace.packets[i % maxNumPkts]
-		flowID = murmur3.Murmur3_32_caida(&pkt.Id)
-		res = detector.Detect(flowID, pkt.Size, pkt.Duration)
-	}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        pkt = trace.packets[i % maxNumPkts]
+        flowID = murmur3.Murmur3_32_caida(&pkt.Id)
+        res = detector.Detect(flowID, pkt.Size, pkt.Duration)
+    }
 }
 
 

--- a/clef/clef.go
+++ b/clef/clef.go
@@ -1,113 +1,113 @@
 package clef
 
 import (
-	"time"
+    "time"
 
-	"github.com/hosslen/lfd/eardet"
-	"github.com/hosslen/lfd/murmur3"
-	"github.com/hosslen/lfd/rlfd"
+    "github.com/hosslen/lfd/eardet"
+    "github.com/hosslen/lfd/murmur3"
+    "github.com/hosslen/lfd/rlfd"
 )
 
 type pktTriple struct {
-	flowID uint32
-	size uint32
-	t time.Duration
+    flowID uint32
+    size uint32
+    t time.Duration
 }
 
 type ClefDtctr struct {
-	//detectors
-	eardet *eardet.EardetDtctr
-	rlfd1 *rlfd.RlfdDtctr
-	rlfd2 *rlfd.RlfdDtctr
+    //detectors
+    eardet *eardet.EardetDtctr
+    rlfd1 *rlfd.RlfdDtctr
+    rlfd2 *rlfd.RlfdDtctr
 
-	//channels
-	packetsForEardet chan pktTriple
-	packetsForRlfd1 chan pktTriple
-	packetsForRlfd2 chan pktTriple
-	resultsEardet chan bool
-	resultsRlfd1 chan bool
-	resultsRlfd2 chan bool
+    //channels
+    packetsForEardet chan pktTriple
+    packetsForRlfd1 chan pktTriple
+    packetsForRlfd2 chan pktTriple
+    resultsEardet chan bool
+    resultsRlfd1 chan bool
+    resultsRlfd2 chan bool
 }
 
 func NewClefDtctr(eardet *eardet.EardetDtctr, rlfd1, rlfd2 *rlfd.RlfdDtctr) *ClefDtctr {
-	cd := &ClefDtctr{}
+    cd := &ClefDtctr{}
 
-	//set detectors
-	cd.eardet = eardet
-	cd.rlfd1 = rlfd1
-	cd.rlfd2 = rlfd2
+    //set detectors
+    cd.eardet = eardet
+    cd.rlfd1 = rlfd1
+    cd.rlfd2 = rlfd2
 
-	//create channels
-	cd.packetsForEardet = make(chan pktTriple, 3)
-	cd.packetsForRlfd1 = make(chan pktTriple, 3)
-	cd.packetsForRlfd2 = make(chan pktTriple, 3)
+    //create channels
+    cd.packetsForEardet = make(chan pktTriple, 3)
+    cd.packetsForRlfd1 = make(chan pktTriple, 3)
+    cd.packetsForRlfd2 = make(chan pktTriple, 3)
 
-	cd.resultsEardet = make(chan bool, 3)
-	cd.resultsRlfd1 = make(chan bool, 3)
-	cd.resultsRlfd2 = make(chan bool, 3)
+    cd.resultsEardet = make(chan bool, 3)
+    cd.resultsRlfd1 = make(chan bool, 3)
+    cd.resultsRlfd2 = make(chan bool, 3)
 
-	//start worker threads
-	go eardetWorker(cd.eardet, cd.packetsForEardet, cd.resultsEardet)
-	go rlfdWorker(cd.rlfd1, cd.packetsForRlfd1, cd.resultsRlfd1)
-	go rlfdWorker(cd.rlfd2, cd.packetsForRlfd2, cd.resultsRlfd2)
+    //start worker threads
+    go eardetWorker(cd.eardet, cd.packetsForEardet, cd.resultsEardet)
+    go rlfdWorker(cd.rlfd1, cd.packetsForRlfd1, cd.resultsRlfd1)
+    go rlfdWorker(cd.rlfd2, cd.packetsForRlfd2, cd.resultsRlfd2)
 
-	return cd
+    return cd
 }
 
 func CleanUpClefDtctr(dtctr *ClefDtctr) {
-	//close channels
-	close(dtctr.packetsForEardet)
-	close(dtctr.packetsForRlfd1)
-	close(dtctr.packetsForRlfd2)
-	close(dtctr.resultsEardet)
-	close(dtctr.resultsRlfd1)
-	close(dtctr.resultsRlfd2)
+    //close channels
+    close(dtctr.packetsForEardet)
+    close(dtctr.packetsForRlfd1)
+    close(dtctr.packetsForRlfd2)
+    close(dtctr.resultsEardet)
+    close(dtctr.resultsRlfd1)
+    close(dtctr.resultsRlfd2)
 }
 
 func (cd *ClefDtctr) SetCurrentTime(now time.Duration) {
-	cd.eardet.SetCurrentTime(now)
-	cd.rlfd1.SetCurrentTime(now)
-	cd.rlfd2.SetCurrentTime(now)
+    cd.eardet.SetCurrentTime(now)
+    cd.rlfd1.SetCurrentTime(now)
+    cd.rlfd2.SetCurrentTime(now)
 }
 
 
 func (cd *ClefDtctr) Detect(id *[16]byte, size uint32, t time.Duration) bool {
-	//TODO: Change this
-	//calculate murmur3 hash
-	flowID := murmur3.Murmur3_32_caida(id)
+    //TODO: Change this
+    //calculate murmur3 hash
+    flowID := murmur3.Murmur3_32_caida(id)
 
-	//create pktTriple
-	pkt := pktTriple{flowID, size, t}
+    //create pktTriple
+    pkt := pktTriple{flowID, size, t}
 
-	//stuff pkt in channels
-	cd.packetsForEardet <- pkt
-	cd.packetsForRlfd1 <- pkt
-	cd.packetsForRlfd2 <- pkt
+    //stuff pkt in channels
+    cd.packetsForEardet <- pkt
+    cd.packetsForRlfd1 <- pkt
+    cd.packetsForRlfd2 <- pkt
 
-	//get results
-	detected := false
-	for i := 0; i < 3; i++ {
-		select {
-			case r := <-cd.resultsEardet:
-				detected = detected || r
-			case r := <-cd.resultsRlfd1:
-				detected = detected || r
-			case r := <-cd.resultsRlfd2:
-				detected = detected || r
-		}
-	}
+    //get results
+    detected := false
+    for i := 0; i < 3; i++ {
+        select {
+            case r := <-cd.resultsEardet:
+                detected = detected || r
+            case r := <-cd.resultsRlfd1:
+                detected = detected || r
+            case r := <-cd.resultsRlfd2:
+                detected = detected || r
+        }
+    }
 
-	return detected
+    return detected
 }
 
 func eardetWorker(dtctr *eardet.EardetDtctr, packets <-chan pktTriple, results chan<- bool) {
-	for p := range packets {
-		results <- dtctr.Detect(p.flowID, p.size, p.t)
-	}
+    for p := range packets {
+        results <- dtctr.Detect(p.flowID, p.size, p.t)
+    }
 }
 
 func rlfdWorker(dtctr *rlfd.RlfdDtctr, packets <-chan pktTriple, results chan<- bool) {
-	for p := range packets {
-		results <- dtctr.Detect(p.flowID, p.size, p.t)
-	}
+    for p := range packets {
+        results <- dtctr.Detect(p.flowID, p.size, p.t)
+    }
 }

--- a/clef/clef_test.go
+++ b/clef/clef_test.go
@@ -1,10 +1,10 @@
 package clef
 
 import (
-	"testing"
-	"fmt"
+    "testing"
+    "fmt"
 )
 
 func TestDoNothing(t *testing.T) {
-	fmt.Println("Do nothing ...")
+    fmt.Println("Do nothing ...")
 }

--- a/eardet/eardet.go
+++ b/eardet/eardet.go
@@ -16,8 +16,8 @@
 package eardet
 
 import (
-	// "fmt"
-	"time"
+    // "fmt"
+    "time"
 )
 
 //TODO:
@@ -25,305 +25,305 @@ import (
 //Change the way we find the new minimum
 
 const (
-	//the number of counters in use (must be > 1)
-	// numCounters uint32 = 128
-	maxuint32 uint32 = 4294967295
+    //the number of counters in use (must be > 1)
+    // numCounters uint32 = 128
+    maxuint32 uint32 = 4294967295
 )
 
 type counter struct {
-	flowID uint32
-	//count is always <= threshold + alpha
-	count uint32
+    flowID uint32
+    //count is always <= threshold + alpha
+    count uint32
 }
 
 type EardetDtctr struct {
-	//the link capacity in Byte/nanosec
-	linkCap float64
-	//maximum packet size
-	alpha uint32
-	//counter threshold relative to zero
-	beta_th uint32
+    //the link capacity in Byte/nanosec
+    linkCap float64
+    //maximum packet size
+    alpha uint32
+    //counter threshold relative to zero
+    beta_th uint32
 
-	beta_l uint32
-	gamma_l float64
-	beta_h uint32
-	gamma_h float64
+    beta_l uint32
+    gamma_l float64
+    beta_h uint32
+    gamma_h float64
 
-	//bucktes
-	counters []counter
-	//points to a bucket with count <= the counts of all other buckets
-	minCounter *counter
-	//the maximum value of count
-	maxValue uint32
-	//count == floor is regarded as being zero
-	floor uint32
-	//threshold for counters that is relative to floor
-	threshold uint32
-	//num counters in EARDet
-	numCounters uint32
+    //bucktes
+    counters []counter
+    //points to a bucket with count <= the counts of all other buckets
+    minCounter *counter
+    //the maximum value of count
+    maxValue uint32
+    //count == floor is regarded as being zero
+    floor uint32
+    //threshold for counters that is relative to floor
+    threshold uint32
+    //num counters in EARDet
+    numCounters uint32
 
-	virtualID uint32
-	maxVirtualPacketSize uint32
+    virtualID uint32
+    maxVirtualPacketSize uint32
 
-	//nanoseconds passed since start of interval
-	currentTime time.Duration
+    //nanoseconds passed since start of interval
+    currentTime time.Duration
 }
 
 //constructors
 // Deprecate this constructor: because this constructor
 // does not translate flow spec to detector setting
 func NewEardetDtctr(
-	numCounters uint32, alpha uint32, beta_th uint32,
-	linkCap float64) *EardetDtctr {
-	ed := &EardetDtctr{}
+    numCounters uint32, alpha uint32, beta_th uint32,
+    linkCap float64) *EardetDtctr {
+    ed := &EardetDtctr{}
     ed.counters = make([]counter, numCounters)
 
-	ed.alpha = alpha
-	ed.beta_th = beta_th
-	ed.threshold = beta_th
-	ed.linkCap = linkCap
-	ed.numCounters = numCounters
+    ed.alpha = alpha
+    ed.beta_th = beta_th
+    ed.threshold = beta_th
+    ed.linkCap = linkCap
+    ed.numCounters = numCounters
 
-	//set minCounter to the last element of counters (all are initialized to 0 anyway)
-	ed.minCounter = &ed.counters[numCounters - 1]
-	ed.maxValue = 0
-	//set maxVirtualPacketSize
-	ed.maxVirtualPacketSize = ed.beta_th - 1
+    //set minCounter to the last element of counters (all are initialized to 0 anyway)
+    ed.minCounter = &ed.counters[numCounters - 1]
+    ed.maxValue = 0
+    //set maxVirtualPacketSize
+    ed.maxVirtualPacketSize = ed.beta_th - 1
 
-	return ed
+    return ed
 }
 
 // beta_th = ((beta_l + (gamma_l * (alpha + beta_l)) / (linkCapacity / (numOfCounters + 1) - gamma_l)) + 1;
 // beta_h = 2 * beta_th + alpha;
 func NewConfigedEardetDtctr(numCounters uint32, alpha uint32, beta_l uint32,
-	gamma_l float64, linkCap float64) *EardetDtctr{
-	ed := &EardetDtctr{}
+    gamma_l float64, linkCap float64) *EardetDtctr{
+    ed := &EardetDtctr{}
     ed.counters = make([]counter, numCounters)
 
-	ed.alpha = alpha
-	gamma_h := linkCap / float64(numCounters + 1)
-	ed.beta_th = uint32(float64(beta_l) + 
-		(gamma_l * float64(alpha + beta_l) / gamma_h - gamma_l) + 1.0)
-	ed.threshold = ed.beta_th
-	ed.linkCap = linkCap
-	ed.numCounters = numCounters
-	ed.beta_l = beta_l
-	ed.gamma_l = gamma_l
-	ed.beta_h = 2 * ed.beta_th + alpha
-	ed.gamma_h = gamma_h
+    ed.alpha = alpha
+    gamma_h := linkCap / float64(numCounters + 1)
+    ed.beta_th = uint32(float64(beta_l) + 
+        (gamma_l * float64(alpha + beta_l) / gamma_h - gamma_l) + 1.0)
+    ed.threshold = ed.beta_th
+    ed.linkCap = linkCap
+    ed.numCounters = numCounters
+    ed.beta_l = beta_l
+    ed.gamma_l = gamma_l
+    ed.beta_h = 2 * ed.beta_th + alpha
+    ed.gamma_h = gamma_h
 
-	//set minCounter to the last element of counters (all are initialized to 0 anyway)
-	ed.minCounter = &ed.counters[numCounters - 1]
-	ed.maxValue = 0
-	//set maxVirtualPacketSize
-	ed.maxVirtualPacketSize = ed.beta_th - 1
+    //set minCounter to the last element of counters (all are initialized to 0 anyway)
+    ed.minCounter = &ed.counters[numCounters - 1]
+    ed.maxValue = 0
+    //set maxVirtualPacketSize
+    ed.maxVirtualPacketSize = ed.beta_th - 1
 
-	return ed
+    return ed
 }
 
 func (ed *EardetDtctr) GetAlpha() uint32 {
-	return ed.alpha
+    return ed.alpha
 }
 
 func (ed *EardetDtctr) GetBeta_th() uint32 {
-	return ed.beta_th
+    return ed.beta_th
 }
 
 func (ed *EardetDtctr) GetBeta_l() uint32 {
-	return ed.beta_l
+    return ed.beta_l
 }
 
 func (ed *EardetDtctr) GetGamma_l() float64 {
-	return ed.gamma_l
+    return ed.gamma_l
 }
 
 func (ed *EardetDtctr) GetBeta_h() uint32 {
-	return ed.beta_h
+    return ed.beta_h
 }
 
 func (ed *EardetDtctr) GetGamma_h() float64 {
-	return ed.gamma_h
+    return ed.gamma_h
 }
 
 func (ed *EardetDtctr) GetNumCounters() uint32 {
-	return ed.numCounters
+    return ed.numCounters
 }
 
 //if the first packets timestamp is not equal to zero, use this
 func (ed *EardetDtctr) SetCurrentTime(now time.Duration) {
-	ed.currentTime = now
+    ed.currentTime = now
 }
 
 //check packet
 func (ed *EardetDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool {
 
-	if (ed.currentTime < t) {
-		//advance currentTime
-		oldTime := ed.currentTime
-		//TODO: deal with the carry
-		ed.currentTime = t + time.Duration(float64(size)/ed.linkCap)
-		
-		//calculate virtual traffic size
-		//TODO: deal with the carry
-		virtualTrafficSize := uint32(float64(t - oldTime)*ed.linkCap) + 1
-		if virtualTrafficSize > ed.maxValue * ed.numCounters {
-			ed.floor = ed.maxValue
-			ed.threshold = ed.floor + ed.beta_th
-		}
+    if (ed.currentTime < t) {
+        //advance currentTime
+        oldTime := ed.currentTime
+        //TODO: deal with the carry
+        ed.currentTime = t + time.Duration(float64(size)/ed.linkCap)
+        
+        //calculate virtual traffic size
+        //TODO: deal with the carry
+        virtualTrafficSize := uint32(float64(t - oldTime)*ed.linkCap) + 1
+        if virtualTrafficSize > ed.maxValue * ed.numCounters {
+            ed.floor = ed.maxValue
+            ed.threshold = ed.floor + ed.beta_th
+        }
 
-		//insert virtual traffic
-		for virtualTrafficSize >= ed.maxVirtualPacketSize {
-			virtualTrafficSize -= ed.maxVirtualPacketSize
-			ed.processPkt(ed.virtualID, ed.maxVirtualPacketSize)
-			ed.virtualID++
-		}
-		if virtualTrafficSize > 0 {
-			ed.processPkt(ed.virtualID, virtualTrafficSize)
-			ed.virtualID++
-		}
-	}
+        //insert virtual traffic
+        for virtualTrafficSize >= ed.maxVirtualPacketSize {
+            virtualTrafficSize -= ed.maxVirtualPacketSize
+            ed.processPkt(ed.virtualID, ed.maxVirtualPacketSize)
+            ed.virtualID++
+        }
+        if virtualTrafficSize > 0 {
+            ed.processPkt(ed.virtualID, virtualTrafficSize)
+            ed.virtualID++
+        }
+    }
 
-	//insert packet
-	return ed.processPkt(flowID, size)
+    //insert packet
+    return ed.processPkt(flowID, size)
 }
 
 //add the packet to counters
 //Note: The assumption is no packet from an already blacklisted flow is passed as argument to this function.
 //If this assumption does not hold, a counter might overflow.
 func (ed *EardetDtctr) processPkt(flowID uint32, size uint32) bool {
-	//get the first bucket
-	index := (flowID & 0xFFFF) % ed.numCounters
-	c := &ed.counters[index]
+    //get the first bucket
+    index := (flowID & 0xFFFF) % ed.numCounters
+    c := &ed.counters[index]
 
-	tries := 0
-	var e, old_c *counter = nil, nil
+    tries := 0
+    var e, old_c *counter = nil, nil
 
-	//check if one of the two candidate buckets already belongs to this flow
-	for tries < 2 {
-		//if yes, increment the counter of that bucket
-		if c.flowID == flowID {
-			c.count += size
-			if c == ed.minCounter {
-				ed.resetMin()
-			}
-			if c.count > ed.maxValue {
-				ed.maxValue = c.count
-			}
-			if c.count > ed.threshold {
-				return true
-			}
-			return false
-		//check if the bucket is empty and if it's the first empty bucket we encounter, store
-		} else if c.count == ed.floor && e == nil {
-			e = c
-		}
-		tries++
-		if tries == 1 {
-			old_c = c
-			c = &ed.counters[((flowID & 0xFFFF0000) >> 16) % ed.numCounters]
-		}
-	}
+    //check if one of the two candidate buckets already belongs to this flow
+    for tries < 2 {
+        //if yes, increment the counter of that bucket
+        if c.flowID == flowID {
+            c.count += size
+            if c == ed.minCounter {
+                ed.resetMin()
+            }
+            if c.count > ed.maxValue {
+                ed.maxValue = c.count
+            }
+            if c.count > ed.threshold {
+                return true
+            }
+            return false
+        //check if the bucket is empty and if it's the first empty bucket we encounter, store
+        } else if c.count == ed.floor && e == nil {
+            e = c
+        }
+        tries++
+        if tries == 1 {
+            old_c = c
+            c = &ed.counters[((flowID & 0xFFFF0000) >> 16) % ed.numCounters]
+        }
+    }
 
-	//check if it is possible to displace any of the counters blocking our
-	//two candidate buckets old_c and c
-	if e == nil {
-		s := &ed.counters[(old_c.flowID & 0xFFFF) % ed.numCounters]
-		if s.count == ed.floor {
-			s.flowID = old_c.flowID
-			s.count = old_c.count
-			e = old_c
-		} else if s = &ed.counters[((old_c.flowID & 0xFFFF0000) >> 16) % ed.numCounters]; s.count == ed.floor {
-			s.flowID = old_c.flowID
-			s.count = old_c.count
-			e = old_c
-		} else if s = &ed.counters[(c.flowID & 0xFFFF) % ed.numCounters]; s.count == ed.floor {
-			s.flowID = c.flowID
-			s.count = c.count
-			e = c
-		} else if s = &ed.counters[((c.flowID & 0xFFFF0000) >> 16) % ed.numCounters]; s.count == ed.floor {
-			s.flowID = c.flowID
-			s.count = c.count
-			e = c
-		}
-		if e != nil {
-			e.count = ed.floor
-			ed.minCounter = e
-		}
-	}
+    //check if it is possible to displace any of the counters blocking our
+    //two candidate buckets old_c and c
+    if e == nil {
+        s := &ed.counters[(old_c.flowID & 0xFFFF) % ed.numCounters]
+        if s.count == ed.floor {
+            s.flowID = old_c.flowID
+            s.count = old_c.count
+            e = old_c
+        } else if s = &ed.counters[((old_c.flowID & 0xFFFF0000) >> 16) % ed.numCounters]; s.count == ed.floor {
+            s.flowID = old_c.flowID
+            s.count = old_c.count
+            e = old_c
+        } else if s = &ed.counters[(c.flowID & 0xFFFF) % ed.numCounters]; s.count == ed.floor {
+            s.flowID = c.flowID
+            s.count = c.count
+            e = c
+        } else if s = &ed.counters[((c.flowID & 0xFFFF0000) >> 16) % ed.numCounters]; s.count == ed.floor {
+            s.flowID = c.flowID
+            s.count = c.count
+            e = c
+        }
+        if e != nil {
+            e.count = ed.floor
+            ed.minCounter = e
+        }
+    }
 
-	//check if we have found a (now) empty bucket
-	if e != nil {
-		e.flowID = flowID
-		e.count = ed.floor + size
-		if e == ed.minCounter {
-			ed.resetMin()
-		}
-		if e.count > ed.maxValue {
-			ed.maxValue = e.count
-		}
-		//check if the threshold is reached
-		if e.count > ed.threshold {
-			return true
-		}
-		return false
-	}
+    //check if we have found a (now) empty bucket
+    if e != nil {
+        e.flowID = flowID
+        e.count = ed.floor + size
+        if e == ed.minCounter {
+            ed.resetMin()
+        }
+        if e.count > ed.maxValue {
+            ed.maxValue = e.count
+        }
+        //check if the threshold is reached
+        if e.count > ed.threshold {
+            return true
+        }
+        return false
+    }
 
-	//if we have not found any bucket, decrement the counts in all buckets
-	m := min(size, ed.minCounter.count - ed.floor)
-	ed.floor += m
-	ed.threshold += m //adjust threshold
+    //if we have not found any bucket, decrement the counts in all buckets
+    m := min(size, ed.minCounter.count - ed.floor)
+    ed.floor += m
+    ed.threshold += m //adjust threshold
 
-	//check again if bucket is zero, insert if yes
-	if old_c.count == ed.floor {
-		old_c.flowID = flowID
-		old_c.count = ed.floor + (size - m)
-		if old_c == ed.minCounter {
-			ed.resetMin()
-		}
-		if old_c.count > ed.threshold {
-			return true
-		}
-	} else if c.count == ed.floor {
-		c.flowID = flowID
-		c.count = ed.floor + (size - m)
-		if c == ed.minCounter {
-			ed.resetMin()
-		}
-		if c.count > ed.threshold {
-			return true
-		}
-	}
-	return false
+    //check again if bucket is zero, insert if yes
+    if old_c.count == ed.floor {
+        old_c.flowID = flowID
+        old_c.count = ed.floor + (size - m)
+        if old_c == ed.minCounter {
+            ed.resetMin()
+        }
+        if old_c.count > ed.threshold {
+            return true
+        }
+    } else if c.count == ed.floor {
+        c.flowID = flowID
+        c.count = ed.floor + (size - m)
+        if c == ed.minCounter {
+            ed.resetMin()
+        }
+        if c.count > ed.threshold {
+            return true
+        }
+    }
+    return false
 }
 
 //calling this function will reset ed.minCounter
 //TODO: Change this
 func (ed *EardetDtctr) resetMin() {
-	c := &ed.counters[0]
-	m := c.count
-	for i := uint32(0); i < ed.numCounters; i++ {
-		if ed.counters[i].count < m {
-			c = &ed.counters[i]
-			m = ed.counters[i].count
-		}
-	}
-	ed.minCounter = c
+    c := &ed.counters[0]
+    m := c.count
+    for i := uint32(0); i < ed.numCounters; i++ {
+        if ed.counters[i].count < m {
+            c = &ed.counters[i]
+            m = ed.counters[i].count
+        }
+    }
+    ed.minCounter = c
 }
 
 //resets the floor to zero
 func (ed *EardetDtctr) resetFloor() {
-	for i := uint32(0); i < ed.numCounters; i++ {
-		ed.counters[i].count -= ed.floor
-	}
-	ed.threshold = ed.beta_th
-	ed.floor = 0
+    for i := uint32(0); i < ed.numCounters; i++ {
+        ed.counters[i].count -= ed.floor
+    }
+    ed.threshold = ed.beta_th
+    ed.floor = 0
 }
 
 func min(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
+    if a < b {
+        return a
+    }
+    return b
 }
 
 

--- a/eardet/eardet_test.go
+++ b/eardet/eardet_test.go
@@ -16,494 +16,494 @@
 package eardet
 
 import (
-	"fmt"
-	"math/rand"
-	"testing"
-	"time"
+    "fmt"
+    "math/rand"
+    "testing"
+    "time"
 )
 
 var (
-	//to facilitate getting a duration for a packet
-	zeroTime = time.Unix(0, 0)
-	//to prevent compiler optimization at the wrong place
-	resGlob bool
-	linkCapacity float32 = 1.25
+    //to facilitate getting a duration for a packet
+    zeroTime = time.Unix(0, 0)
+    //to prevent compiler optimization at the wrong place
+    resGlob bool
+    linkCapacity float32 = 1.25
 )
 
 //test the min function
 func TestMin(t *testing.T) {
-	var tests = []struct{
-		a uint32
-		b uint32
-		want uint32
-	}{
-		{1, 2, 1},
-		{2, 1, 1},
-		{2, 2, 2},
-	}
-	for _, test := range tests {
-		if got := min(test.a, test.b); got != test.want {
-			t.Errorf("min(%d, %d) = %d", test.a, test.b, got)
-		}
-	}
+    var tests = []struct{
+        a uint32
+        b uint32
+        want uint32
+    }{
+        {1, 2, 1},
+        {2, 1, 1},
+        {2, 2, 2},
+    }
+    for _, test := range tests {
+        if got := min(test.a, test.b); got != test.want {
+            t.Errorf("min(%d, %d) = %d", test.a, test.b, got)
+        }
+    }
 }
 
 //test that resetFloor works correctly
 func TestResetFloor(t *testing.T) {
-	var tests = []struct{
-		alpha uint32
-		beta_th uint32
-		floor uint32
-	}{
-		{100, 200 + numCounters, 200},
-		{100, 100 + numCounters, 0},
-	}
-	for _, test := range tests {
-		//set up
-		ed := NewEardetDtctr(128, test.alpha, test.beta_th, linkCapacity)
-		ed.floor = test.floor
-		//fill buckets to simulate a raised floor
-		for i := uint32(0); i < numCounters; i++ {
-			ed.counters[i].count = ed.floor + i
-		}
-		//test that the buckets are properly decremented
-		temp := ed.minCounter
-		ed.resetFloor()
-		for i := uint32(0); i < numCounters; i++ {
-			if ed.counters[i].count != i {
-				t.Errorf("resetFloor failed: Bucket %d should be %d but is %d.",
-				 i, i, ed.counters[i].count)
-				break
-			}
-		}
-		//test that floor is zero
-		if ed.floor != 0 {
-			t.Errorf("resetFloor failed: floor is %d but should be %d.", ed.floor, 0)
-		}
-		//test that minCounter does not change
-		if temp != ed.minCounter {
-			t.Errorf("resetFloor failed: minCounter has changed from %p to %p.", temp, ed.minCounter)
-		}
-	}
+    var tests = []struct{
+        alpha uint32
+        beta_th uint32
+        floor uint32
+    }{
+        {100, 200 + numCounters, 200},
+        {100, 100 + numCounters, 0},
+    }
+    for _, test := range tests {
+        //set up
+        ed := NewEardetDtctr(128, test.alpha, test.beta_th, linkCapacity)
+        ed.floor = test.floor
+        //fill buckets to simulate a raised floor
+        for i := uint32(0); i < numCounters; i++ {
+            ed.counters[i].count = ed.floor + i
+        }
+        //test that the buckets are properly decremented
+        temp := ed.minCounter
+        ed.resetFloor()
+        for i := uint32(0); i < numCounters; i++ {
+            if ed.counters[i].count != i {
+                t.Errorf("resetFloor failed: Bucket %d should be %d but is %d.",
+                 i, i, ed.counters[i].count)
+                break
+            }
+        }
+        //test that floor is zero
+        if ed.floor != 0 {
+            t.Errorf("resetFloor failed: floor is %d but should be %d.", ed.floor, 0)
+        }
+        //test that minCounter does not change
+        if temp != ed.minCounter {
+            t.Errorf("resetFloor failed: minCounter has changed from %p to %p.", temp, ed.minCounter)
+        }
+    }
 }
 
 //test that minCounter is reset properly if resetMin is called
 func TestResetMin(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(1000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//fill buckets
-	for i := uint32(0); i < numCounters; i++ {
-		ed.counters[i].count = 150
-	}
-	//test with last bucket containing the smallest count
-	ed.counters[(numCounters - 1) % numCounters].count = 100
-	ed.resetMin()
-	if ed.minCounter != findMin(ed) {
-		t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
-		 ed.minCounter, findMin(ed))
-	}
-	//test with random bucket containing the smallest count
-	source := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(source)
-	randNum := r.Uint32()
-	ed.counters[randNum % numCounters].count = 50
-	ed.resetMin()
-	if ed.minCounter != findMin(ed) {
-		t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
-		 ed.minCounter, findMin(ed))
-	}
-	//test with first bucket containing the smallest count
-	ed.counters[0].count = 25
-	ed.resetMin()
-	if ed.minCounter != findMin(ed) {
-		t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
-		 ed.minCounter, findMin(ed))
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(1000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //fill buckets
+    for i := uint32(0); i < numCounters; i++ {
+        ed.counters[i].count = 150
+    }
+    //test with last bucket containing the smallest count
+    ed.counters[(numCounters - 1) % numCounters].count = 100
+    ed.resetMin()
+    if ed.minCounter != findMin(ed) {
+        t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
+         ed.minCounter, findMin(ed))
+    }
+    //test with random bucket containing the smallest count
+    source := rand.NewSource(time.Now().UnixNano())
+    r := rand.New(source)
+    randNum := r.Uint32()
+    ed.counters[randNum % numCounters].count = 50
+    ed.resetMin()
+    if ed.minCounter != findMin(ed) {
+        t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
+         ed.minCounter, findMin(ed))
+    }
+    //test with first bucket containing the smallest count
+    ed.counters[0].count = 25
+    ed.resetMin()
+    if ed.minCounter != findMin(ed) {
+        t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
+         ed.minCounter, findMin(ed))
+    }
 }
 
 func findMin(ed *EardetDtctr) *counter {
-	temp := &ed.counters[0]
-	for i := 0; i < len(ed.counters); i++ {
-		if temp.count > ed.counters[i].count {
-			temp = &ed.counters[i]
-		}
-	}
-	return temp
+    temp := &ed.counters[0]
+    for i := 0; i < len(ed.counters); i++ {
+        if temp.count > ed.counters[i].count {
+            temp = &ed.counters[i]
+        }
+    }
+    return temp
 }
 
 //test if minCounter is reset after inserting packets (resetMin is called)
 func TestMinCounterIsResetAfterPacketInsertion(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(1000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//insert a packets
-	i := 0
-	for ;i < len(ed.counters) - 1; i++ {
-		ed.processPkt(uint32(i), 100)
-	}
-	ed.processPkt(uint32(i), 50)
-	
-	if ed.minCounter != findMin(ed) {
-		t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
-		 ed.minCounter, findMin(ed))
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(1000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //insert a packets
+    i := 0
+    for ;i < len(ed.counters) - 1; i++ {
+        ed.processPkt(uint32(i), 100)
+    }
+    ed.processPkt(uint32(i), 50)
+    
+    if ed.minCounter != findMin(ed) {
+        t.Errorf("resetMin failed: ed.minCounter=%p, should be %p",
+         ed.minCounter, findMin(ed))
+    }
 }
 
 //insert a packet into the first matching bucket, count of that bucket is zero
 func TestProcessPktInsertNewFlowInZeroBucket(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//insert a packet into the first bucket
-	res := ed.processPkt(0, 200)
-	if res {
-		t.Errorf("processPkt failed: Packet(0, 200) wrongly detected.")
-	}
-	if ed.counters[0].count != 200 {
-		t.Errorf("processPkt failed: Packet(0, 200) not correctly inserted.")
-	}
-	if b, i := allOtherBucketsAreZero(ed, 0); !b {
-		t.Errorf("processPkt failed: Bucket %d is not zero.", i)
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //insert a packet into the first bucket
+    res := ed.processPkt(0, 200)
+    if res {
+        t.Errorf("processPkt failed: Packet(0, 200) wrongly detected.")
+    }
+    if ed.counters[0].count != 200 {
+        t.Errorf("processPkt failed: Packet(0, 200) not correctly inserted.")
+    }
+    if b, i := allOtherBucketsAreZero(ed, 0); !b {
+        t.Errorf("processPkt failed: Bucket %d is not zero.", i)
+    }
 }
 
 //insert a packet into the first matching bucket, the bucket count has already been incremented
 func TestProcessPktInsertFlowInAlreadyIncrementedBucket(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	flowid1 := uint32(1)
-	//insert a packet with flow id 6
-	res0 := ed.processPkt(flowid1, 500)
-	res1 := ed.processPkt(flowid1, 600)
-	if res0 {
-		t.Errorf("processPkt failed: Packet(%d, 500) wrongly detected.", flowid1)
-	} 
-	if res1 {
-		t.Errorf("processPkt failed: Packet(%d, 600) wrongly detected.", flowid1)
-	}
-	if ed.counters[1 % numCounters].count != 1100 {
-		t.Errorf("processPkt failed: Packet(6, 500) or Packet(6, 600) not correctly inserted.")
-	}
-	if b, i := allOtherBucketsAreZero(ed, 1); !b {
-		t.Errorf("processPkt failed: Bucket %d is not zero.", i)
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    flowid1 := uint32(1)
+    //insert a packet with flow id 6
+    res0 := ed.processPkt(flowid1, 500)
+    res1 := ed.processPkt(flowid1, 600)
+    if res0 {
+        t.Errorf("processPkt failed: Packet(%d, 500) wrongly detected.", flowid1)
+    } 
+    if res1 {
+        t.Errorf("processPkt failed: Packet(%d, 600) wrongly detected.", flowid1)
+    }
+    if ed.counters[1 % numCounters].count != 1100 {
+        t.Errorf("processPkt failed: Packet(6, 500) or Packet(6, 600) not correctly inserted.")
+    }
+    if b, i := allOtherBucketsAreZero(ed, 1); !b {
+        t.Errorf("processPkt failed: Bucket %d is not zero.", i)
+    }
 }
 
 //insert a packet into the second matching bucket, the first matching bucket is already taken by another flow
 func TestProcessPktInsertFlowInAlternateBucket(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	flowid1 := uint32(0x00000000)
-	flowid2 := uint32(0x00010000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//insert first packet
-	res0 := ed.processPkt(flowid1, 500)
-	//insert second packet
-	res1 := ed.processPkt(flowid2, 600)
-	if res0 {
-		t.Errorf("processPkt failed: Packet(%d, 500) wrongly detected.", flowid1)
-	} 
-	if res1 {
-		t.Errorf("processPkt failed: Packet(%d, 600) wrongly detected.", flowid2)
-	}
-	if ed.counters[((flowid2 & 0xFFFF0000) >> 16) % numCounters].count != 600 {
-		t.Errorf("processPkt failed: Packet(%x, 600) not correctly inserted.", flowid2)
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    flowid1 := uint32(0x00000000)
+    flowid2 := uint32(0x00010000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //insert first packet
+    res0 := ed.processPkt(flowid1, 500)
+    //insert second packet
+    res1 := ed.processPkt(flowid2, 600)
+    if res0 {
+        t.Errorf("processPkt failed: Packet(%d, 500) wrongly detected.", flowid1)
+    } 
+    if res1 {
+        t.Errorf("processPkt failed: Packet(%d, 600) wrongly detected.", flowid2)
+    }
+    if ed.counters[((flowid2 & 0xFFFF0000) >> 16) % numCounters].count != 600 {
+        t.Errorf("processPkt failed: Packet(%x, 600) not correctly inserted.", flowid2)
+    }
 }
 
 //both matching buckets are already taken by other flows, here floor is not raised
 func TestInsertionFails(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	flowid1 := uint32(0)
-	flowid2 := uint32(0x00010000)
-	flowid3 := uint32(0x00020000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//insert first and second packet
-	ed.processPkt(flowid1, 500)
-	ed.processPkt(flowid2, 600)
-	// printAllBuckets(ed)
-	res := ed.processPkt(flowid3, 300)
-	if res {
-		t.Errorf("processPkt failed: Packet(%d, 300) wrongly detected.", flowid3)
-	} 
-	if ed.floor != 0 && numCounters > 2 {
-		t.Errorf("processPkt failed: floor not properly set, is %d should be %d.", ed.floor, 0)
-	}
-	if ed.counters[flowid1 % numCounters].count != 500 {
-		t.Errorf("processPkt failed: Packet(%d, 500) not correctly inserted.", flowid1)
-	}
-	if ed.counters[(flowid2 & 0xFFFF0000 >> 16) % numCounters].count != 600 {
-		t.Errorf("processPkt failed: Packet(%d, 600) not correctly inserted.", flowid2)
-	}
-	// printAllBuckets(ed)
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    flowid1 := uint32(0)
+    flowid2 := uint32(0x00010000)
+    flowid3 := uint32(0x00020000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //insert first and second packet
+    ed.processPkt(flowid1, 500)
+    ed.processPkt(flowid2, 600)
+    // printAllBuckets(ed)
+    res := ed.processPkt(flowid3, 300)
+    if res {
+        t.Errorf("processPkt failed: Packet(%d, 300) wrongly detected.", flowid3)
+    } 
+    if ed.floor != 0 && numCounters > 2 {
+        t.Errorf("processPkt failed: floor not properly set, is %d should be %d.", ed.floor, 0)
+    }
+    if ed.counters[flowid1 % numCounters].count != 500 {
+        t.Errorf("processPkt failed: Packet(%d, 500) not correctly inserted.", flowid1)
+    }
+    if ed.counters[(flowid2 & 0xFFFF0000 >> 16) % numCounters].count != 600 {
+        t.Errorf("processPkt failed: Packet(%d, 600) not correctly inserted.", flowid2)
+    }
+    // printAllBuckets(ed)
 }
 
 //both matching buckets are already taken by other flows, here floor is raised
 func TestInsertionFailsFloorIsRaised(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	flowid1 := uint32(numCounters + 1)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    flowid1 := uint32(numCounters + 1)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
 
-	//insert packets
-	for i := uint32(0); i < numCounters; i++ {
-		ed.processPkt(i, alpha_test + i)
-	}
-	res := ed.processPkt(flowid1, 600)
+    //insert packets
+    for i := uint32(0); i < numCounters; i++ {
+        ed.processPkt(i, alpha_test + i)
+    }
+    res := ed.processPkt(flowid1, 600)
 
-	if res {
-		t.Errorf("processPkt failed: Packet(%d, 600) wrongly detected.", flowid1)
-	} 
-	if ed.floor != alpha_test {
-		t.Errorf("processPkt failed: floor not properly set, is %d should be %d.", ed.floor, alpha_test)
-	}
-	if ed.minCounter != findMin(ed) {
-		t.Errorf("processPkt failed: ed.minCounter=%p, should be %p",
-		 ed.minCounter, findMin(ed))
-	}
+    if res {
+        t.Errorf("processPkt failed: Packet(%d, 600) wrongly detected.", flowid1)
+    } 
+    if ed.floor != alpha_test {
+        t.Errorf("processPkt failed: floor not properly set, is %d should be %d.", ed.floor, alpha_test)
+    }
+    if ed.minCounter != findMin(ed) {
+        t.Errorf("processPkt failed: ed.minCounter=%p, should be %p",
+         ed.minCounter, findMin(ed))
+    }
 }
 
 //Insert a packet into an empty bucket, test if it is detected as too big
 func TestProcessPktInsertTooBig1(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	flowid1 := uint32(numCounters + 1)
-	size1 := uint32(50001)
-	//insert packet
-	if !ed.processPkt(flowid1, size1) {
-		t.Errorf("processPkt failed: Returns false, should return true.")
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    flowid1 := uint32(numCounters + 1)
+    size1 := uint32(50001)
+    //insert packet
+    if !ed.processPkt(flowid1, size1) {
+        t.Errorf("processPkt failed: Returns false, should return true.")
+    }
 }
 
 //Insert a packet into an already partly filled bucket, test if it is detected
 func TestProcessPktInsertTooBig2(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	flowid1 := uint32(numCounters + 1)
-	size1 := uint32(2501)
-	//insert packet
-	if ed.processPkt(flowid1, size1) {
-		t.Errorf("processPkt failed: Returns true, should return false.")
-	}
-	if !ed.processPkt(flowid1, size1) {
-		t.Errorf("processPkt failed: Returns false, should return true.")
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    flowid1 := uint32(numCounters + 1)
+    size1 := uint32(2501)
+    //insert packet
+    if ed.processPkt(flowid1, size1) {
+        t.Errorf("processPkt failed: Returns true, should return false.")
+    }
+    if !ed.processPkt(flowid1, size1) {
+        t.Errorf("processPkt failed: Returns false, should return true.")
+    }
 }
 
 //test that after raising the floor the rest of a packet is inserted correctly in the first matching bucket
 func TestInsertAfterRaisingFloor1(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//insert a packet into every bucket
-	for i := uint32(0); i < numCounters; i++ {
-		ed.processPkt(i, 100)
-	}
-	//insert another packet
-	res := ed.processPkt(numCounters, 5200)
-	// printAllBuckets(ed)
-	if !res {
-		t.Errorf("processPkt failed: returns false, should return true")
-	}
-	if ed.counters[0].count != 5200 {
-		t.Errorf("processPkt failed: count of bucket 0 is %d, should be %d.", ed.counters[0].count, 5200)
-	}
-	if ed.floor != 100 {
-		t.Errorf("processPkt Failed: floor should be 100, but is %d.", ed.floor)
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //insert a packet into every bucket
+    for i := uint32(0); i < numCounters; i++ {
+        ed.processPkt(i, 100)
+    }
+    //insert another packet
+    res := ed.processPkt(numCounters, 5200)
+    // printAllBuckets(ed)
+    if !res {
+        t.Errorf("processPkt failed: returns false, should return true")
+    }
+    if ed.counters[0].count != 5200 {
+        t.Errorf("processPkt failed: count of bucket 0 is %d, should be %d.", ed.counters[0].count, 5200)
+    }
+    if ed.floor != 100 {
+        t.Errorf("processPkt Failed: floor should be 100, but is %d.", ed.floor)
+    }
 }
 
 //test that after raising the floor the rest of a packet is inserted correctly in the second matching bucket
 func TestInsertAfterRaisingFloor2(t *testing.T) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	flowid1 := uint32(0x00010000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
-	//insert a packet into every bucket
-	for i := uint32(0); i < numCounters; i++ {
-		ed.processPkt(i, 100)
-	}
-	//insert another packet
-	ed.processPkt(0, 100)
-	res := ed.processPkt(flowid1, 5200)
-	if !res {
-		t.Errorf("processPkt failed: returns false, should return true")
-	}
-	if ed.counters[((flowid1 & 0xFFFF0000) >> 16) % numCounters].count != 5200 {
-		t.Errorf("processPkt failed: count of bucket 0 is %d, should be %d.", ed.counters[((flowid1 & 0xFFFF0000) >> 16)].count, 5200)
-	}
-	if ed.floor != 100 {
-		t.Errorf("processPkt Failed: floor should be 100, but is %d.", ed.floor)
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    flowid1 := uint32(0x00010000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, linkCapacity)
+    //insert a packet into every bucket
+    for i := uint32(0); i < numCounters; i++ {
+        ed.processPkt(i, 100)
+    }
+    //insert another packet
+    ed.processPkt(0, 100)
+    res := ed.processPkt(flowid1, 5200)
+    if !res {
+        t.Errorf("processPkt failed: returns false, should return true")
+    }
+    if ed.counters[((flowid1 & 0xFFFF0000) >> 16) % numCounters].count != 5200 {
+        t.Errorf("processPkt failed: count of bucket 0 is %d, should be %d.", ed.counters[((flowid1 & 0xFFFF0000) >> 16)].count, 5200)
+    }
+    if ed.floor != 100 {
+        t.Errorf("processPkt Failed: floor should be 100, but is %d.", ed.floor)
+    }
 }
 
 //this function should insert one virtual traffic packet before the real packet
 func TestDetectBasicInsert(t *testing.T) {
-	ed := NewEardetDtctr(128, 500, 5000, 0.03)
-	ed.Detect(1, 300, 600)
-	if ed.counters[0].count != 19 {
-		t.Errorf("Virtual traffic should increment bucket 0 to 19 but has to %d", ed.counters[0].count)
-	}
-	if ed.counters[1 % numCounters].count != 300 {
-		t.Errorf("Real packet should increment bucket 1 to 300 but has to %d", 
-			ed.counters[1 % numCounters].count)
-	}
-	// printAllBuckets(ed)
+    ed := NewEardetDtctr(128, 500, 5000, 0.03)
+    ed.Detect(1, 300, 600)
+    if ed.counters[0].count != 19 {
+        t.Errorf("Virtual traffic should increment bucket 0 to 19 but has to %d", ed.counters[0].count)
+    }
+    if ed.counters[1 % numCounters].count != 300 {
+        t.Errorf("Real packet should increment bucket 1 to 300 but has to %d", 
+            ed.counters[1 % numCounters].count)
+    }
+    // printAllBuckets(ed)
 }
 
 //this function should insert multiple virtual traffic packets before the real packet
 func TestDetectInsertMultiple(t *testing.T) {
-	ed := NewEardetDtctr(128, 500, 1000, 0.03)
-	ed.Detect(numCounters, 300, 60000)
-	if ed.counters[0].count != 999 {
-		t.Errorf("Virtual traffic should increment bucket 0 to 999 but has to %d", ed.counters[0].count)
-	}
-	if ed.floor != 0 {
-		t.Errorf("floor should be 0 but is %d.", 
-			ed.floor)
-	}
-	// printAllBuckets(ed)
+    ed := NewEardetDtctr(128, 500, 1000, 0.03)
+    ed.Detect(numCounters, 300, 60000)
+    if ed.counters[0].count != 999 {
+        t.Errorf("Virtual traffic should increment bucket 0 to 999 but has to %d", ed.counters[0].count)
+    }
+    if ed.floor != 0 {
+        t.Errorf("floor should be 0 but is %d.", 
+            ed.floor)
+    }
+    // printAllBuckets(ed)
 }
 
 //test cuckoo hashing
 func TestDisplacement1(t *testing.T) {
-	ed := NewEardetDtctr(128, 500, 1000, linkCapacity)
-	ed.processPkt(0x00020001, 100)
-	ed.processPkt(0x00040003, 200)
-	ed.processPkt(0x00030001, 300)
-	if ed.counters[2].count != 100 {
-		t.Errorf("Virtual traffic should increment bucket 2 to 100 but has to %d", ed.counters[2].count)
-	}
-	if ed.counters[3].count != 200 {
-		t.Errorf("Virtual traffic should increment bucket 3 to 200 but has to %d", ed.counters[3].count)
-	}
-	if ed.counters[1].count != 300 {
-		t.Errorf("Virtual traffic should increment bucket 1 to 300 but has to %d", ed.counters[1].count)
-	}
+    ed := NewEardetDtctr(128, 500, 1000, linkCapacity)
+    ed.processPkt(0x00020001, 100)
+    ed.processPkt(0x00040003, 200)
+    ed.processPkt(0x00030001, 300)
+    if ed.counters[2].count != 100 {
+        t.Errorf("Virtual traffic should increment bucket 2 to 100 but has to %d", ed.counters[2].count)
+    }
+    if ed.counters[3].count != 200 {
+        t.Errorf("Virtual traffic should increment bucket 3 to 200 but has to %d", ed.counters[3].count)
+    }
+    if ed.counters[1].count != 300 {
+        t.Errorf("Virtual traffic should increment bucket 1 to 300 but has to %d", ed.counters[1].count)
+    }
 }
 
 //test cuckoo hashing
 func TestDisplacement2(t *testing.T) {
-	ed := NewEardetDtctr(128, 500, 1000, linkCapacity)
-	ed.processPkt(0x00030001, 100)
-	ed.processPkt(0x00020003, 400)
-	ed.processPkt(0x00040002, 200)
-	ed.processPkt(0x00020001, 300)
-	if ed.counters[2].count != 300 {
-		t.Errorf("Virtual traffic should increment bucket 2 to 300 but has to %d", ed.counters[2].count)
-	}
-	if ed.counters[1].count != 100 {
-		t.Errorf("Virtual traffic should increment bucket 1 to 100 but has to %d", ed.counters[1].count)
-	}
-	if ed.counters[4].count != 200 {
-		t.Errorf("Virtual traffic should increment bucket 4 to 200 but has to %d", ed.counters[4].count)
-	}
-	// printAllBuckets(ed)
+    ed := NewEardetDtctr(128, 500, 1000, linkCapacity)
+    ed.processPkt(0x00030001, 100)
+    ed.processPkt(0x00020003, 400)
+    ed.processPkt(0x00040002, 200)
+    ed.processPkt(0x00020001, 300)
+    if ed.counters[2].count != 300 {
+        t.Errorf("Virtual traffic should increment bucket 2 to 300 but has to %d", ed.counters[2].count)
+    }
+    if ed.counters[1].count != 100 {
+        t.Errorf("Virtual traffic should increment bucket 1 to 100 but has to %d", ed.counters[1].count)
+    }
+    if ed.counters[4].count != 200 {
+        t.Errorf("Virtual traffic should increment bucket 4 to 200 but has to %d", ed.counters[4].count)
+    }
+    // printAllBuckets(ed)
 }
 
 //test cuckoo hashing
 func TestDisplacement3(t *testing.T) {
-	ed := NewEardetDtctr(128, 500, 1000, linkCapacity)
-	ed.processPkt(0, 500)
-	ed.processPkt(0x00020001, 700)
-	ed.processPkt(0x00040003, 800)
-	ed.processPkt(0x00030001, 500)
-	ed.processPkt(0x00030002, 500)
-	for i := 5; i < len(ed.counters); i++ {
-		ed.processPkt(uint32(i), 500)
-	}
-	//decrement floor by 500
-	ed.processPkt(numCounters, 500)
-	ed.processPkt(0x00040002, 900)
-	ed.processPkt(0x00040001, 1000)
+    ed := NewEardetDtctr(128, 500, 1000, linkCapacity)
+    ed.processPkt(0, 500)
+    ed.processPkt(0x00020001, 700)
+    ed.processPkt(0x00040003, 800)
+    ed.processPkt(0x00030001, 500)
+    ed.processPkt(0x00030002, 500)
+    for i := 5; i < len(ed.counters); i++ {
+        ed.processPkt(uint32(i), 500)
+    }
+    //decrement floor by 500
+    ed.processPkt(numCounters, 500)
+    ed.processPkt(0x00040002, 900)
+    ed.processPkt(0x00040001, 1000)
 
-	if ed.counters[1].count != 700 {
-		t.Errorf("Virtual traffic should increment bucket 1 to 700 but has to %d", ed.counters[1].count)
-	}
-	if ed.counters[3].count != 800 {
-		t.Errorf("Virtual traffic should increment bucket 3 to 800 but has to %d", ed.counters[3].count)
-	}
-	if ed.counters[4].count != 1500 {
-		t.Errorf("Virtual traffic should increment bucket 4 to 1500 but has to %d", ed.counters[4].count)
-	}
-	// printAllBuckets(ed)
+    if ed.counters[1].count != 700 {
+        t.Errorf("Virtual traffic should increment bucket 1 to 700 but has to %d", ed.counters[1].count)
+    }
+    if ed.counters[3].count != 800 {
+        t.Errorf("Virtual traffic should increment bucket 3 to 800 but has to %d", ed.counters[3].count)
+    }
+    if ed.counters[4].count != 1500 {
+        t.Errorf("Virtual traffic should increment bucket 4 to 1500 but has to %d", ed.counters[4].count)
+    }
+    // printAllBuckets(ed)
 }
 
 func TestOverflow(t *testing.T) {
-	num := maxuint32
-	num++
-	if num != 0 {
-		t.Errorf("%d + 1 does not overflow as I thought it would.", maxuint32)
-	}
-	
+    num := maxuint32
+    num++
+    if num != 0 {
+        t.Errorf("%d + 1 does not overflow as I thought it would.", maxuint32)
+    }
+    
 }
 
 func allOtherBucketsAreZero(ed *EardetDtctr, flowid uint32) (bool, uint32) {
-	for i := uint32(0); i < numCounters; i++ {
-		if ed.counters[i].count != 0 && i != (flowid % numCounters) {
-			return false, i
-		}
-	}
-	return true, 0
+    for i := uint32(0); i < numCounters; i++ {
+        if ed.counters[i].count != 0 && i != (flowid % numCounters) {
+            return false, i
+        }
+    }
+    return true, 0
 }
 
 func printAllBuckets(ed *EardetDtctr) {
-	for i := uint32(0); i < numCounters; i++ {
-		fmt.Printf("%d: id=%d count=%d\n", i, ed.counters[i].flowID, ed.counters[i].count)
-	}
+    for i := uint32(0); i < numCounters; i++ {
+        fmt.Printf("%d: id=%d count=%d\n", i, ed.counters[i].flowID, ed.counters[i].count)
+    }
 }
 
 func makeRandomInput(n int) [][2]uint32 {
-	rSlice := make([][2]uint32, n)
-	source := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(source)
-	for i := 0; i < n; i++ {
-		rSlice[i][0] = r.Uint32()
-		rSlice[i][1] = uint32(rand.Intn(1000))
-	}
-	return rSlice
+    rSlice := make([][2]uint32, n)
+    source := rand.NewSource(time.Now().UnixNano())
+    r := rand.New(source)
+    for i := 0; i < n; i++ {
+        rSlice[i][0] = r.Uint32()
+        rSlice[i][1] = uint32(rand.Intn(1000))
+    }
+    return rSlice
 }
 
 // func TestMakeRandomInput(t *testing.T) {
-// 	fmt.Println(makeRandomInput(10))
+//  fmt.Println(makeRandomInput(10))
 // }
 
 func BenchmarkProcessPktInsertBasic(b *testing.B) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, 0)
-	rSlice := makeRandomInput(b.N)
-	var randID uint32
-	var randSize uint32	
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		randID = rSlice[i][0]
-		randSize = rSlice[i][1]
-		resGlob = ed.processPkt(randID, randSize)	
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, 0)
+    rSlice := makeRandomInput(b.N)
+    var randID uint32
+    var randSize uint32 
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        randID = rSlice[i][0]
+        randSize = rSlice[i][1]
+        resGlob = ed.processPkt(randID, randSize)   
+    }
 }
 
 func BenchmarkDetectInsertBasic(b *testing.B) {
-	alpha_test := uint32(500)
-	beta_th_test := uint32(5000)
-	ed := NewEardetDtctr(128, alpha_test, beta_th_test, 0)
-	rSlice := makeRandomInput(b.N)
-	var randID uint32
-	var randSize uint32
-	var now time.Duration	
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		randID = rSlice[i][0]
-		randSize = rSlice[i][1]
-		//fmt.Printf("%d %d %d\n", randID, randSize, now)
-		resGlob = ed.Detect(randID, randSize, now)
-		now += 2	
-	}
+    alpha_test := uint32(500)
+    beta_th_test := uint32(5000)
+    ed := NewEardetDtctr(128, alpha_test, beta_th_test, 0)
+    rSlice := makeRandomInput(b.N)
+    var randID uint32
+    var randSize uint32
+    var now time.Duration   
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        randID = rSlice[i][0]
+        randSize = rSlice[i][1]
+        //fmt.Printf("%d %d %d\n", randID, randSize, now)
+        resGlob = ed.Detect(randID, randSize, now)
+        now += 2    
+    }
 }
 
 

--- a/murmur3/murmur3.go
+++ b/murmur3/murmur3.go
@@ -2,94 +2,94 @@
 package murmur3
 
 import (
-	"crypto/rand"
-	"encoding/binary"
-	"fmt"
-	"os"
-	"unsafe"
+    "crypto/rand"
+    "encoding/binary"
+    "fmt"
+    "os"
+    "unsafe"
 )
 
 var seed uint32 = 0
 
 // resets the seed of the hashfunction, uses the pseudo random generator of crypto/rand
 func ResetSeed() {
-	s := make([]byte, 4)
-	_, err := rand.Read(s)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		return
-	}
-	seed = binary.LittleEndian.Uint32(s)
+    s := make([]byte, 4)
+    _, err := rand.Read(s)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "%v\n", err)
+        return
+    }
+    seed = binary.LittleEndian.Uint32(s)
 }
 
 func setSeed(s uint32) {
-	seed = s
+    seed = s
 }
 
 func GetSeed() uint32 {
-	return seed
+    return seed
 }
 
 // implementation of murmur hash https://en.wikipedia.org/wiki/MurmurHash
 func Murmur3_32(key *[8]byte) uint32 {
-	arrayPointer := (*[2]uint32)(unsafe.Pointer(key))
-	hash := seed
-	var k uint32
-	for i := 0; i < 2; i++ {
-		k = (*arrayPointer)[i]
+    arrayPointer := (*[2]uint32)(unsafe.Pointer(key))
+    hash := seed
+    var k uint32
+    for i := 0; i < 2; i++ {
+        k = (*arrayPointer)[i]
 
-		k *= 0xcc9e2d51
-		k = (k << 15) | (k >> 17)
-		k *= 0x1b873593
+        k *= 0xcc9e2d51
+        k = (k << 15) | (k >> 17)
+        k *= 0x1b873593
 
-		hash ^= k
-		hash = (hash << 13) | (hash >> 19)
-		hash *= 5
-		hash += 0xe6546b64
-	}
+        hash ^= k
+        hash = (hash << 13) | (hash >> 19)
+        hash *= 5
+        hash += 0xe6546b64
+    }
 
-	//here we would deal with the remaining bytes
-	//there are none in this case
+    //here we would deal with the remaining bytes
+    //there are none in this case
 
-	hash ^= 8
+    hash ^= 8
 
-	hash ^= (hash >> 16)
-	hash *= 0x85ebca6b
-	hash ^= (hash >> 13)
-	hash *= 0xc2b2ae35
-	hash ^= (hash >> 16)
+    hash ^= (hash >> 16)
+    hash *= 0x85ebca6b
+    hash ^= (hash >> 13)
+    hash *= 0xc2b2ae35
+    hash ^= (hash >> 16)
 
-	return hash
+    return hash
 }
 
 //for the caida packet traces
 func Murmur3_32_caida(key *[16]byte) uint32 {
-	arrayPointer := (*[4]uint32)(unsafe.Pointer(key))
-	hash := seed
-	var k uint32
-	for i := 0; i < 4; i++ {
-		k = (*arrayPointer)[i]
+    arrayPointer := (*[4]uint32)(unsafe.Pointer(key))
+    hash := seed
+    var k uint32
+    for i := 0; i < 4; i++ {
+        k = (*arrayPointer)[i]
 
-		k *= 0xcc9e2d51
-		k = (k << 15) | (k >> 17)
-		k *= 0x1b873593
+        k *= 0xcc9e2d51
+        k = (k << 15) | (k >> 17)
+        k *= 0x1b873593
 
-		hash ^= k
-		hash = (hash << 13) | (hash >> 19)
-		hash *= 5
-		hash += 0xe6546b64
-	}
+        hash ^= k
+        hash = (hash << 13) | (hash >> 19)
+        hash *= 5
+        hash += 0xe6546b64
+    }
 
-	//here we would deal with the remaining bytes
-	//there are none in this case
+    //here we would deal with the remaining bytes
+    //there are none in this case
 
-	hash ^= 16
+    hash ^= 16
 
-	hash ^= (hash >> 16)
-	hash *= 0x85ebca6b
-	hash ^= (hash >> 13)
-	hash *= 0xc2b2ae35
-	hash ^= (hash >> 16)
+    hash ^= (hash >> 16)
+    hash *= 0x85ebca6b
+    hash ^= (hash >> 13)
+    hash *= 0xc2b2ae35
+    hash ^= (hash >> 16)
 
-	return hash
+    return hash
 }

--- a/murmur3/murmur3_test.go
+++ b/murmur3/murmur3_test.go
@@ -2,81 +2,81 @@
 package murmur3
 
 import (
-	"math/rand"
-	"testing"
-	"time"
-	"unsafe"
+    "math/rand"
+    "testing"
+    "time"
+    "unsafe"
 
-	spaolacciMurmur "github.com/spaolacci/murmur3"
+    spaolacciMurmur "github.com/spaolacci/murmur3"
 )
 
 var r uint32 = 0
 
 func TestMurmur_32CorrectDeterministic(t *testing.T) {
-	var tests = []struct{
-		input [8]byte
-	}{
-		{[8]byte{0, 0, 0, 0, 0, 0, 0, 0}},
-		{[8]byte{1, 0, 0, 0, 0, 0, 0, 0}},
-		{[8]byte{2, 3, 2, 255, 2, 3, 2, 3}},
-		{[8]byte{3, 0, 3, 0, 3, 0, 3, 0}},
-		{[8]byte{0, 0, 0, 4, 5, 0, 0, 0}},
-		{[8]byte{9, 0, 8, 0, 7, 0, 6, 0}},
-		{[8]byte{7, 6, 5, 4, 3, 2, 1, 0}},
-		{[8]byte{255, 255, 255, 255, 255, 255, 255, 255}},
-	}
-	setSeed(0) //since the spaolacci implementation always uses seed = 0
-	for i := 0; i < len(tests); i++ {
-		res := Murmur3_32(&(tests[i].input))
-		exp := spaolacciMurmur.Sum32((tests[i].input)[:])
-		if res != exp {
-			t.Errorf("murmur3 failed: Got 0x%x, expected 0x%x\n", res, exp)
-		}
-	}
+    var tests = []struct{
+        input [8]byte
+    }{
+        {[8]byte{0, 0, 0, 0, 0, 0, 0, 0}},
+        {[8]byte{1, 0, 0, 0, 0, 0, 0, 0}},
+        {[8]byte{2, 3, 2, 255, 2, 3, 2, 3}},
+        {[8]byte{3, 0, 3, 0, 3, 0, 3, 0}},
+        {[8]byte{0, 0, 0, 4, 5, 0, 0, 0}},
+        {[8]byte{9, 0, 8, 0, 7, 0, 6, 0}},
+        {[8]byte{7, 6, 5, 4, 3, 2, 1, 0}},
+        {[8]byte{255, 255, 255, 255, 255, 255, 255, 255}},
+    }
+    setSeed(0) //since the spaolacci implementation always uses seed = 0
+    for i := 0; i < len(tests); i++ {
+        res := Murmur3_32(&(tests[i].input))
+        exp := spaolacciMurmur.Sum32((tests[i].input)[:])
+        if res != exp {
+            t.Errorf("murmur3 failed: Got 0x%x, expected 0x%x\n", res, exp)
+        }
+    }
 }
 
 func TestMurmur_32CorrectRandom(t *testing.T) {
-	tests := makeInput(100)
-	setSeed(0) //since the spaolacci implementation always uses seed = 0
-	for i := 0; i < len(tests); i++ {
-		res := Murmur3_32(&tests[i])
-		exp := spaolacciMurmur.Sum32(tests[i][:])
-		if res != exp {
-			t.Errorf("murmur3(0x%x) failed: Got 0x%x, expected 0x%x\n", *((* uint64)(unsafe.Pointer(&tests[i]))), res, exp)
-		}
-	}
+    tests := makeInput(100)
+    setSeed(0) //since the spaolacci implementation always uses seed = 0
+    for i := 0; i < len(tests); i++ {
+        res := Murmur3_32(&tests[i])
+        exp := spaolacciMurmur.Sum32(tests[i][:])
+        if res != exp {
+            t.Errorf("murmur3(0x%x) failed: Got 0x%x, expected 0x%x\n", *((* uint64)(unsafe.Pointer(&tests[i]))), res, exp)
+        }
+    }
 }
 
 //make random input for the benchmarks
 func makeInput(n int) [][8]byte {
-	s := make([][8]byte, n)
-	source := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(source)
-	randNum := uint64(0)
-	for i := 0; i < n; i++ {
-		randNum = uint64(r.Uint32()) << 32 + uint64(r.Uint32())
-		s[i] = *((* [8]byte)(unsafe.Pointer(&randNum)))
-	}
-	return s
+    s := make([][8]byte, n)
+    source := rand.NewSource(time.Now().UnixNano())
+    r := rand.New(source)
+    randNum := uint64(0)
+    for i := 0; i < n; i++ {
+        randNum = uint64(r.Uint32()) << 32 + uint64(r.Uint32())
+        s[i] = *((* [8]byte)(unsafe.Pointer(&randNum)))
+    }
+    return s
 }
 
 func BenchmarkSpaolacciMurmur(b *testing.B) {
-	// key := [8]byte{1, 0, 0, 0, 0, 6, 0, 0}
-	// k := key[:]
-	input := makeInput(b.N)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		r = spaolacciMurmur.Sum32(input[i][:])
-	}
+    // key := [8]byte{1, 0, 0, 0, 0, 6, 0, 0}
+    // k := key[:]
+    input := makeInput(b.N)
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        r = spaolacciMurmur.Sum32(input[i][:])
+    }
 }
 
 func BenchmarkMyMurmur(b *testing.B) {
-	// key := [8]byte{1, 0, 0, 0, 0, 6, 0, 0}
-	// k := &key
-	ResetSeed()
-	input := makeInput(b.N)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		r = Murmur3_32(&input[i])
-	}
+    // key := [8]byte{1, 0, 0, 0, 0, 6, 0, 0}
+    // k := &key
+    ResetSeed()
+    input := makeInput(b.N)
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        r = Murmur3_32(&input[i])
+    }
 }

--- a/rlfd/rlfd.go
+++ b/rlfd/rlfd.go
@@ -2,158 +2,158 @@
 package rlfd
 
 import (
-	"time"
-	"fmt"
-	// "github.com/hosslen/lfd/murmur3"
+    "time"
+    "fmt"
+    // "github.com/hosslen/lfd/murmur3"
 )
 
 var _ = fmt.Println
 
 const (
-	//number of counters in a virtual counter node
-	m = uint32(8)
-	//s = log2(m)
-	s = uint32(3)
-	//must hold: s * d < 32
-	//depth of the virtual counter tree
-	d = uint32(7)
-	//must hold: d >= roundUp(logm(n)) (n = number of flows)
+    //number of counters in a virtual counter node
+    m = uint32(8)
+    //s = log2(m)
+    s = uint32(3)
+    //must hold: s * d < 32
+    //depth of the virtual counter tree
+    d = uint32(7)
+    //must hold: d >= roundUp(logm(n)) (n = number of flows)
 )
 
 type counter struct {
-	flowID uint32
-	count uint32
-	//indicates if count is current or from last phase
-	reset bool
+    flowID uint32
+    count uint32
+    //indicates if count is current or from last phase
+    reset bool
 }
 
 type RlfdDtctr struct {
-	counters [m]counter
-	//threshold for counters, th_rlfd = gamma*t_l + beta must hold
-	th_rlfd uint32
-	//time spent on one level in ns
-	t_l time.Duration
+    counters [m]counter
+    //threshold for counters, th_rlfd = gamma*t_l + beta must hold
+    th_rlfd uint32
+    //time spent on one level in ns
+    t_l time.Duration
 
-	//level we are on now
-	level uint32
-	//to track the maximum counter
-	maxIndex uint8
-	maxVal uint32
-	//time
-	now time.Duration
-	//indicates what counter.reset should be right now, if it is not, count is considered to be zero
-	reset bool
-	numCountersReseted uint32
-	//to check if a flowID hashed into a loaded virtual counter
-	bitmaskIndex uint32
-	bitmaskPath uint32
-	path uint32
+    //level we are on now
+    level uint32
+    //to track the maximum counter
+    maxIndex uint8
+    maxVal uint32
+    //time
+    now time.Duration
+    //indicates what counter.reset should be right now, if it is not, count is considered to be zero
+    reset bool
+    numCountersReseted uint32
+    //to check if a flowID hashed into a loaded virtual counter
+    bitmaskIndex uint32
+    bitmaskPath uint32
+    path uint32
 }
 
 //returns a pointer to a new rlfdDtctr
 func NewRlfdDtctr(beta uint32, gamma float64, t_l time.Duration) *RlfdDtctr {
-	rd := &RlfdDtctr{}
+    rd := &RlfdDtctr{}
 
-	rd.t_l = t_l
-	rd.th_rlfd = uint32(gamma*float64(t_l)) + beta
-	rd.level = 0
-	rd.bitmaskIndex = ((1 << s) - 1) << (32 - s) //(2^s - 1) << (32 - s)
-	rd.bitmaskPath = 0
-	rd.path = 0
-	rd.reset = true
+    rd.t_l = t_l
+    rd.th_rlfd = uint32(gamma*float64(t_l)) + beta
+    rd.level = 0
+    rd.bitmaskIndex = ((1 << s) - 1) << (32 - s) //(2^s - 1) << (32 - s)
+    rd.bitmaskPath = 0
+    rd.path = 0
+    rd.reset = true
 
-	return rd
+    return rd
 }
 
 func (rd *RlfdDtctr) SetCurrentTime(t time.Duration) {
-	rd.now = t
+    rd.now = t
 }
 
 func (rd *RlfdDtctr) Detect(flowID uint32, size uint32, t time.Duration) bool {
-	//check if we advance one level
-	diff := t - rd.now
-	if (diff > rd.t_l) {
-		rd.now += rd.t_l*(diff / rd.t_l)
-		if (rd.level == d - 1) {
-			rd.bitmaskIndex = 0xe0000000
-			rd.bitmaskPath = 0
-			rd.level = 0
-			rd.path = 0
-			// murmur3.ResetSeed()
-		} else {
-			temp1 := 29 - (rd.level * 3)
-			temp2 := uint32(0x7 << temp1)
-			rd.bitmaskIndex >>= 3
-			rd.bitmaskPath = rd.bitmaskPath | temp2
-			rd.level++
-			rd.path = rd.path | (uint32(rd.maxIndex) << temp1)
-		}
-		rd.maxVal = 0
-		if rd.numCountersReseted < m {
-			for i := uint32(0); i < m; i++ {
-				rd.counters[i].reset = rd.reset
-			}
-		}
-		rd.numCountersReseted = 0
-		rd.reset = !rd.reset
-	}
+    //check if we advance one level
+    diff := t - rd.now
+    if (diff > rd.t_l) {
+        rd.now += rd.t_l*(diff / rd.t_l)
+        if (rd.level == d - 1) {
+            rd.bitmaskIndex = 0xe0000000
+            rd.bitmaskPath = 0
+            rd.level = 0
+            rd.path = 0
+            // murmur3.ResetSeed()
+        } else {
+            temp1 := 29 - (rd.level * 3)
+            temp2 := uint32(0x7 << temp1)
+            rd.bitmaskIndex >>= 3
+            rd.bitmaskPath = rd.bitmaskPath | temp2
+            rd.level++
+            rd.path = rd.path | (uint32(rd.maxIndex) << temp1)
+        }
+        rd.maxVal = 0
+        if rd.numCountersReseted < m {
+            for i := uint32(0); i < m; i++ {
+                rd.counters[i].reset = rd.reset
+            }
+        }
+        rd.numCountersReseted = 0
+        rd.reset = !rd.reset
+    }
 
-	//is the right virtual counter loaded?
-	if (flowID & rd.bitmaskPath) == rd.path {
-		index := uint8((flowID & rd.bitmaskIndex) >> (29 - (3 * rd.level)))
-		c := &rd.counters[index]
+    //is the right virtual counter loaded?
+    if (flowID & rd.bitmaskPath) == rd.path {
+        index := uint8((flowID & rd.bitmaskIndex) >> (29 - (3 * rd.level)))
+        c := &rd.counters[index]
 
-		//are we on the lowest level?
-		if rd.level == d - 1 {
-			//do cuckoo hashing
-			var alt bool
-			altIndex := (flowID & 0x38) >> 3
-			if (c.flowID == flowID && c.reset == rd.reset) {
-				c.count += size
-			} else if c2 := &rd.counters[altIndex]; c2.flowID == flowID && c2.reset == rd.reset {
-				c2.count += size
-				alt = true
-			} else if c.reset != rd.reset {
-				c.count = size
-				c.flowID = flowID
-				c.reset = rd.reset
-				rd.numCountersReseted++
-			} else if c2 := &rd.counters[((c.flowID & 0x38) >> 3)]; c2.reset != rd.reset {
-				c2.count = c.count
-				c2.flowID = c.flowID
-				c2.reset = rd.reset
-				rd.numCountersReseted++
-				c.count = size
-				c.flowID = flowID
-			} else {
-				return false
-			}
+        //are we on the lowest level?
+        if rd.level == d - 1 {
+            //do cuckoo hashing
+            var alt bool
+            altIndex := (flowID & 0x38) >> 3
+            if (c.flowID == flowID && c.reset == rd.reset) {
+                c.count += size
+            } else if c2 := &rd.counters[altIndex]; c2.flowID == flowID && c2.reset == rd.reset {
+                c2.count += size
+                alt = true
+            } else if c.reset != rd.reset {
+                c.count = size
+                c.flowID = flowID
+                c.reset = rd.reset
+                rd.numCountersReseted++
+            } else if c2 := &rd.counters[((c.flowID & 0x38) >> 3)]; c2.reset != rd.reset {
+                c2.count = c.count
+                c2.flowID = c.flowID
+                c2.reset = rd.reset
+                rd.numCountersReseted++
+                c.count = size
+                c.flowID = flowID
+            } else {
+                return false
+            }
 
-			//check threshold
-			if size > rd.th_rlfd {
-				return true
-			} else if c.count > rd.th_rlfd && !alt {
-				return true
-			} else if alt && rd.counters[altIndex].count > rd.th_rlfd {
-				return true
-			}
-		//we are not on the lowest level
-		} else {
-			if c.reset != rd.reset {
-				c.count = size
-				c.reset = rd.reset
-				rd.numCountersReseted++
-			} else {
-				c.count += size
-			}
-			//reset max if necessary
-			if (c.count > rd.maxVal) {
-				rd.maxIndex = index
-				rd.maxVal = c.count
-			}
-		}
-	}
-	return false
+            //check threshold
+            if size > rd.th_rlfd {
+                return true
+            } else if c.count > rd.th_rlfd && !alt {
+                return true
+            } else if alt && rd.counters[altIndex].count > rd.th_rlfd {
+                return true
+            }
+        //we are not on the lowest level
+        } else {
+            if c.reset != rd.reset {
+                c.count = size
+                c.reset = rd.reset
+                rd.numCountersReseted++
+            } else {
+                c.count += size
+            }
+            //reset max if necessary
+            if (c.count > rd.maxVal) {
+                rd.maxIndex = index
+                rd.maxVal = c.count
+            }
+        }
+    }
+    return false
 }
 
 

--- a/rlfd/rlfd_test.go
+++ b/rlfd/rlfd_test.go
@@ -1,192 +1,192 @@
 package rlfd
 
 import (
-	"math/rand"
-	"testing"
-	"time"
+    "math/rand"
+    "testing"
+    "time"
 
-	"fmt"
+    "fmt"
 )
 
 const max = uint32(4294967295)
 
 var (
-	beta = uint32(500)
-	gamma = uint32(200)
-	t_l = time.Duration(500)
-	_ = fmt.Println
+    beta = uint32(500)
+    gamma = uint32(200)
+    t_l = time.Duration(500)
+    _ = fmt.Println
 )
 
 //insert a simple package
 func TestBasicInsert(t *testing.T) {
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	flowID := rand.Uint32()
-	size := uint32(500)
-	timestamp := time.Duration(0)
-	detector.Detect(flowID, size, timestamp)
-	index := (flowID & (((1 << s) - 1) << (32 - s))) >> (32 - s)
-	// fmt.Println((flowID & (((1 << s) - 1) << (32 - s))))
-	if detector.level != 0 {
-		t.Errorf("Detect failed: level is %d, should be 0.\n", detector.level)
-	}
-	if detector.counters[index].count != size {
-		t.Errorf("Detect failed: count is %d, should be %d.\n", detector.counters[index].count, size)
-	}
-	if !detector.counters[index].reset {
-		t.Errorf("Detect failed: reset is %t, should be true.\n", detector.counters[index].reset)
-	}
-	// fmt.Println(detector.counters)
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    flowID := rand.Uint32()
+    size := uint32(500)
+    timestamp := time.Duration(0)
+    detector.Detect(flowID, size, timestamp)
+    index := (flowID & (((1 << s) - 1) << (32 - s))) >> (32 - s)
+    // fmt.Println((flowID & (((1 << s) - 1) << (32 - s))))
+    if detector.level != 0 {
+        t.Errorf("Detect failed: level is %d, should be 0.\n", detector.level)
+    }
+    if detector.counters[index].count != size {
+        t.Errorf("Detect failed: count is %d, should be %d.\n", detector.counters[index].count, size)
+    }
+    if !detector.counters[index].reset {
+        t.Errorf("Detect failed: reset is %t, should be true.\n", detector.counters[index].reset)
+    }
+    // fmt.Println(detector.counters)
 }
 
 //test if level is raised correctly
 func TestLevelRaising(t *testing.T) {
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	flowID := rand.Uint32() & ((^uint32(0)) >> s)
-	size := uint32(500)
-	timestamp := t_l + 1
-	oldLevel := detector.level
-	detector.Detect(flowID, size, timestamp)
-	index := (flowID & (((1 << s) - 1) << (32 - 2*s))) >> (32 - 2*s)
-	if detector.level != oldLevel + 1 {
-		t.Errorf("Detect failed: level is %d, should be %d.\n", detector.level, oldLevel + 1)
-	}
-	if detector.counters[index].count != size {
-		t.Errorf("Detect failed: count is %d, should be %d.\n", detector.counters[index].count, size)
-	}
-	if detector.counters[index].reset {
-		t.Errorf("Detect failed: reset is %t, should be true.\n", detector.counters[index].reset)
-	}
-	if detector.now != t_l {
-		t.Errorf("Detect failed: t_l is %d, should be %d.\n", detector.t_l, t_l)
-	}
-	// fmt.Println(detector.counters)
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    flowID := rand.Uint32() & ((^uint32(0)) >> s)
+    size := uint32(500)
+    timestamp := t_l + 1
+    oldLevel := detector.level
+    detector.Detect(flowID, size, timestamp)
+    index := (flowID & (((1 << s) - 1) << (32 - 2*s))) >> (32 - 2*s)
+    if detector.level != oldLevel + 1 {
+        t.Errorf("Detect failed: level is %d, should be %d.\n", detector.level, oldLevel + 1)
+    }
+    if detector.counters[index].count != size {
+        t.Errorf("Detect failed: count is %d, should be %d.\n", detector.counters[index].count, size)
+    }
+    if detector.counters[index].reset {
+        t.Errorf("Detect failed: reset is %t, should be true.\n", detector.counters[index].reset)
+    }
+    if detector.now != t_l {
+        t.Errorf("Detect failed: t_l is %d, should be %d.\n", detector.t_l, t_l)
+    }
+    // fmt.Println(detector.counters)
 }
 
 //insert two simple packages
 func TestInsertTwo(t *testing.T) {
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	flowID := uint32(0x20000000)
-	size := uint32(500)
-	timestamp := time.Duration(0)
-	detector.Detect(flowID, size, timestamp)
-	detector.Detect(flowID, size, timestamp + 1)
-	index := (flowID & (((1 << s) - 1) << (32 - s))) >> (32 - s)
-	if detector.level != 0 {
-		t.Errorf("Detect failed: level is %d, should be 0.\n", detector.level)
-	}
-	if detector.counters[index].count != 2*size {
-		t.Errorf("Detect failed: count is %d, should be %d.\n", detector.counters[index].count, 2*size)
-	}
-	if !detector.counters[index].reset {
-		t.Errorf("Detect failed: reset is %t, should be true.\n", detector.counters[index].reset)
-	}
-	//fmt.Println(detector.counters)
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    flowID := uint32(0x20000000)
+    size := uint32(500)
+    timestamp := time.Duration(0)
+    detector.Detect(flowID, size, timestamp)
+    detector.Detect(flowID, size, timestamp + 1)
+    index := (flowID & (((1 << s) - 1) << (32 - s))) >> (32 - s)
+    if detector.level != 0 {
+        t.Errorf("Detect failed: level is %d, should be 0.\n", detector.level)
+    }
+    if detector.counters[index].count != 2*size {
+        t.Errorf("Detect failed: count is %d, should be %d.\n", detector.counters[index].count, 2*size)
+    }
+    if !detector.counters[index].reset {
+        t.Errorf("Detect failed: reset is %t, should be true.\n", detector.counters[index].reset)
+    }
+    //fmt.Println(detector.counters)
 }
 
 
 func TestSetPathCorrectly(t *testing.T) {
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	flowIDs := [7]uint32{0x20000000, 0x28000000, 0x29800000, 0x29C00000, 0x29CA0000, 0x29CB8000, 0x29CBB800}
-	sizes := [7]uint32{100, 200, 300, 400, 500, 600, 700}
-	timestamps := [7]time.Duration{0, t_l + 1, 2*t_l + 1, 3*t_l + 1, 4*t_l + 1, 5*t_l + 1, 6*t_l + 1}
-	expectedPaths := [7]uint32{0x0, 0x20000000, 0x28000000, 0x29800000, 0x29c00000, 0x29ca0000, 0x29cb8000}
-	for i := 0; i < 7; i++ {
-		detector.Detect(flowIDs[i], sizes[i], timestamps[i])
-		if detector.path != expectedPaths[i] {
-			t.Errorf("Detect failed: path is not set correctly, should be 0x%x but is 0x%x.\n", 
-				expectedPaths[i], detector.path)
-		}
-		if uint32(i) != detector.level {
-			t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
-				i, detector.level)
-		}
-		// fmt.Println(detector.counters)
-	}
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    flowIDs := [7]uint32{0x20000000, 0x28000000, 0x29800000, 0x29C00000, 0x29CA0000, 0x29CB8000, 0x29CBB800}
+    sizes := [7]uint32{100, 200, 300, 400, 500, 600, 700}
+    timestamps := [7]time.Duration{0, t_l + 1, 2*t_l + 1, 3*t_l + 1, 4*t_l + 1, 5*t_l + 1, 6*t_l + 1}
+    expectedPaths := [7]uint32{0x0, 0x20000000, 0x28000000, 0x29800000, 0x29c00000, 0x29ca0000, 0x29cb8000}
+    for i := 0; i < 7; i++ {
+        detector.Detect(flowIDs[i], sizes[i], timestamps[i])
+        if detector.path != expectedPaths[i] {
+            t.Errorf("Detect failed: path is not set correctly, should be 0x%x but is 0x%x.\n", 
+                expectedPaths[i], detector.path)
+        }
+        if uint32(i) != detector.level {
+            t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
+                i, detector.level)
+        }
+        // fmt.Println(detector.counters)
+    }
 }
 
 func TestSameFlowOverManyLevelsAlwaysSameBucket(t *testing.T) {
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	flowID := uint32(0x24924800)
-	size := uint32(100)
-	timestamps := [7]time.Duration{0, t_l + 1, 2*t_l + 1, 3*t_l + 1, 4*t_l + 1, 5*t_l + 1, 6*t_l + 1}
-	expectedPaths := [7]uint32{0x0, 0x20000000, 0x24000000, 0x24800000, 0x24900000, 0x24920000, 0x24924000}
-	for i := 0; i < 7; i++ {
-		detector.Detect(flowID, size, timestamps[i])
-		if detector.path != expectedPaths[i] {
-			t.Errorf("Detect failed: path is not set correctly, should be 0x%x but is 0x%x.\n", 
-				expectedPaths[i], detector.path)
-		}
-		if uint32(i) != detector.level {
-			t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
-				i, detector.level)
-		}
-		if detector.counters[1 % m].count != size {
-			t.Errorf("Detect failed: count is not set correctly, should be %d but is %d.\n",
-			 size, detector.counters[1 % m].count)
-		}
-		if detector.counters[1 % m].reset != detector.reset {
-			t.Errorf("Detect failed: reset is not set correctly, should be %t but is %t.\n",
-			 detector.reset, detector.counters[1 % m].reset)
-		}
-	}
-	if detector.counters[1 % m].flowID != flowID {
-		t.Errorf("Detect failed: flowID is not set correctly, should be %d but is %d.\n",
-		 flowID, detector.counters[1 % m].flowID)
-	}
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    flowID := uint32(0x24924800)
+    size := uint32(100)
+    timestamps := [7]time.Duration{0, t_l + 1, 2*t_l + 1, 3*t_l + 1, 4*t_l + 1, 5*t_l + 1, 6*t_l + 1}
+    expectedPaths := [7]uint32{0x0, 0x20000000, 0x24000000, 0x24800000, 0x24900000, 0x24920000, 0x24924000}
+    for i := 0; i < 7; i++ {
+        detector.Detect(flowID, size, timestamps[i])
+        if detector.path != expectedPaths[i] {
+            t.Errorf("Detect failed: path is not set correctly, should be 0x%x but is 0x%x.\n", 
+                expectedPaths[i], detector.path)
+        }
+        if uint32(i) != detector.level {
+            t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
+                i, detector.level)
+        }
+        if detector.counters[1 % m].count != size {
+            t.Errorf("Detect failed: count is not set correctly, should be %d but is %d.\n",
+             size, detector.counters[1 % m].count)
+        }
+        if detector.counters[1 % m].reset != detector.reset {
+            t.Errorf("Detect failed: reset is not set correctly, should be %t but is %t.\n",
+             detector.reset, detector.counters[1 % m].reset)
+        }
+    }
+    if detector.counters[1 % m].flowID != flowID {
+        t.Errorf("Detect failed: flowID is not set correctly, should be %d but is %d.\n",
+         flowID, detector.counters[1 % m].flowID)
+    }
 }
 
 func TestDetectFlow(t *testing.T) {
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	flowID := uint32(0x24924800)
-	size := uint32(100600)
-	timestamps := [7]time.Duration{0, t_l + 1, 2*t_l + 1, 3*t_l + 1, 4*t_l + 1, 5*t_l + 1, 6*t_l + 1}
-	expectedPaths := [7]uint32{0x0, 0x20000000, 0x24000000, 0x24800000, 0x24900000, 0x24920000, 0x24924000}
-	var res bool
-	for i := 0; i < 7; i++ {
-		res = detector.Detect(flowID, size, timestamps[i])
-		if i < 6 && res {
-			t.Errorf("Detect failed: returns %t but should return %t.\n",
-			 res, false)
-		}
-		if i == 6 && !res {
-			t.Errorf("Detect failed: returns %t but should return %t.\n",
-			 res, true)
-		}
-		if detector.path != expectedPaths[i] {
-			t.Errorf("Detect failed: path is not set correctly, should be 0x%x but is 0x%x.\n", 
-				expectedPaths[i], detector.path)
-		}
-		if uint32(i) != detector.level {
-			t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
-				i, detector.level)
-		}
-		if detector.counters[1 % m].count != size {
-			t.Errorf("Detect failed: count is not set correctly, should be %d but is %d.\n",
-			 size, detector.counters[1 % m].count)
-		}
-		if detector.counters[1 % m].reset != detector.reset {
-			t.Errorf("Detect failed: reset is not set correctly, should be %t but is %t.\n",
-			 detector.reset, detector.counters[1 % m].reset)
-		}
-	}
-	if detector.counters[1 % m].flowID != flowID {
-		t.Errorf("Detect failed: flowID is not set correctly, should be %d but is %d.\n",
-		 flowID, detector.counters[1 % m].flowID)
-	}
-	// fmt.Println(detector.counters)
-	// fmt.Println(detector.th_rlfd)
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    flowID := uint32(0x24924800)
+    size := uint32(100600)
+    timestamps := [7]time.Duration{0, t_l + 1, 2*t_l + 1, 3*t_l + 1, 4*t_l + 1, 5*t_l + 1, 6*t_l + 1}
+    expectedPaths := [7]uint32{0x0, 0x20000000, 0x24000000, 0x24800000, 0x24900000, 0x24920000, 0x24924000}
+    var res bool
+    for i := 0; i < 7; i++ {
+        res = detector.Detect(flowID, size, timestamps[i])
+        if i < 6 && res {
+            t.Errorf("Detect failed: returns %t but should return %t.\n",
+             res, false)
+        }
+        if i == 6 && !res {
+            t.Errorf("Detect failed: returns %t but should return %t.\n",
+             res, true)
+        }
+        if detector.path != expectedPaths[i] {
+            t.Errorf("Detect failed: path is not set correctly, should be 0x%x but is 0x%x.\n", 
+                expectedPaths[i], detector.path)
+        }
+        if uint32(i) != detector.level {
+            t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
+                i, detector.level)
+        }
+        if detector.counters[1 % m].count != size {
+            t.Errorf("Detect failed: count is not set correctly, should be %d but is %d.\n",
+             size, detector.counters[1 % m].count)
+        }
+        if detector.counters[1 % m].reset != detector.reset {
+            t.Errorf("Detect failed: reset is not set correctly, should be %t but is %t.\n",
+             detector.reset, detector.counters[1 % m].reset)
+        }
+    }
+    if detector.counters[1 % m].flowID != flowID {
+        t.Errorf("Detect failed: flowID is not set correctly, should be %d but is %d.\n",
+         flowID, detector.counters[1 % m].flowID)
+    }
+    // fmt.Println(detector.counters)
+    // fmt.Println(detector.th_rlfd)
 }
 
 func TestTime(t *testing.T) {
-	now := 7*t_l + 5
-	detector := NewRlfdDtctr(beta, gamma, t_l)
-	detector.SetCurrentTime(now)
-	detector.Detect(0, 0, now + 2*t_l + 1)
-	detector.Detect(0, 0, now + 2*t_l + 2)
-	if detector.level != 1 {
-		t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
-			1, detector.level)
-	}
+    now := 7*t_l + 5
+    detector := NewRlfdDtctr(beta, gamma, t_l)
+    detector.SetCurrentTime(now)
+    detector.Detect(0, 0, now + 2*t_l + 1)
+    detector.Detect(0, 0, now + 2*t_l + 2)
+    if detector.level != 1 {
+        t.Errorf("Detect failed: level is not set correctly, should be %d but is %d.\n",
+            1, detector.level)
+    }
 }
 
 


### PR DESCRIPTION
Due to the tab indentation is weird, we usually use 4-spaces indentation.

@simonschdev for you last PR, could you also replace all tab indentations with 4-space indentations?

I am using sublime here, so it can just replace all in one file with one click. For other editors, I believe there should be some way to do this without manually convert them one by one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lfd/10)
<!-- Reviewable:end -->
