### PR TITLE
Load and evaluate synthetic trace from txt file

### DIFF
--- a/main/config_for_txt_trace.json
+++ b/main/config_for_txt_trace.json
@@ -1,0 +1,21 @@
+{
+    "exp_name": "test_exp",
+    "traffic_config": {
+        "link_capacity": 125000000,
+        "max_pkt_num": 2600000,       
+        "flow_spec_gamma": 12500,
+        "flow_spec_beta": 3028,
+        "max_pkt_size": 1514,
+        "txt_trace_file": "../resource/synthetic-trace/synthetic-trace.txt"
+    },
+    "EARDet_config": {
+        "gamma_low": 12500,
+        "gamma_high": 125000,
+        "beta_low": 6056
+    },
+    "RLFD_config": {
+        "gamma": 12500,
+        "beta": 6056,
+        "t_l_factor": 1.0
+    }
+}

--- a/main/evaluator.go
+++ b/main/evaluator.go
@@ -30,6 +30,7 @@ type Config struct {
         FlowSpecBeta int `json:"flow_spec_beta"`
         PcapFile string `json:"pcap_file"`
         TimeFile string `json:"time_file"`
+        TxtTraceFile string `json:"txt_trace_file"`
     } `json:"traffic_config"`
     EARDetConfig struct {
         GammaLow int `json:"gamma_low"`
@@ -68,6 +69,7 @@ func main() {
     maxPktNum := config.TrafficConfig.MaxPacketNum
     pcapFilename := config.TrafficConfig.PcapFile
     timesFilename := config.TrafficConfig.TimeFile
+    txtTraceFilename := config.TrafficConfig.TxtTraceFile
 
     // link capacity 10Gbps = 1.25B/ns
     p := float64(config.TrafficConfig.LinkCapacity) / NANO_SEC_PER_SEC
@@ -93,8 +95,15 @@ func main() {
     rd_gamma := float64(config.RLFDConfig.Gamma) / NANO_SEC_PER_SEC
     rd_beta := uint32(config.RLFDConfig.Beta)
 
-    trace := caida.LoadPCAPFile(pcapFilename, timesFilename, maxPktNum)
-
+    var trace *caida.TraceData
+    if pcapFilename != "" && timesFilename != "" {
+        trace = caida.LoadPCAPFile(pcapFilename, timesFilename, maxPktNum)
+    } else if txtTraceFilename != "" {
+        trace = caida.LoadTxtTraceFile(txtTraceFilename, maxPktNum)
+    } else {
+        fmt.Println("Please provide a trace file either in pcap or txt")
+        os.Exit(1)
+    }
 
     //FP and FN
     edFP := 0

--- a/resource/synthetic-trace/README.txt
+++ b/resource/synthetic-trace/README.txt
@@ -1,0 +1,2 @@
+This synthetic trace is generated with 10 large flows at rate 1250000 B/s
+and 10000 legitimate flows at rate 12500 B/s. All flows are flat flows.

--- a/resource/synthetic-trace/synthetic-trace-config.json
+++ b/resource/synthetic-trace/synthetic-trace-config.json
@@ -1,0 +1,61 @@
+{
+    "exp_name": "full_link_flat_20171125",
+    "run_EARDet": true,
+    "run_EFD": false,
+    "run_FMF": false,
+    "run_AMF": false,
+    "run_EARDet_EFD": false,
+    "run_FMD": false,
+    "debug_mode": false,
+    "traffic_config": {
+        "inbound_link_capacity": 500000000,
+        "outbound_link_capacity": 125000000,
+        "time_interval": 10,
+        "per_flow_reservation": 12500,
+        "full_use_flow_packet_size": 500,
+        "num_full_use_flows": 10000,
+        "num_under_use_flows": 0,
+        "attack_flow_packet_size": 500,
+        "num_attack_flows": 10,
+        "is_burst_attack": false,
+        "burst_duty_cycle_ratio": 0.1,
+        "burst_period_to_efd_period": 15,
+        "max_packet_size": 1514,
+        "flow_spec_burst_tolerance": 3028,
+        "max_num_admitted_flows": 10000,
+    },
+    "EARDet_config": {
+        "gamma_low": 12500,
+        "gamma_high": 125000,
+        "beta_low": 3028,
+        "max_incubation_time": 1.0,
+    },
+    "EFD_config": {
+        "gamma": 12500,
+        "burst": 3028,
+        "split_by_relative_value": false,
+    },
+    "FMF_config": {
+        "period": 0.2,
+        "num_stages": 4,
+        "flow_memory": true,
+        "flow_memory_counter_ratio": 0.5,
+        "least_value_eviction": false,
+    },
+    "AMF_config": {
+        "num_stages": 4,
+        "flow_memory": true,
+        "flow_memory_counter_ratio": 0.5,
+        "least_value_eviction": false,
+    },
+    "EARDet_EFD_config": {
+        "EFD_split_by_relative_value": false,
+        "EARDet_counter_ratio": 0.5,
+        "twin_EFD": true,
+        "twin_EFD_Tc2_adjust": 1.5,
+    },
+    "FMD_config": {
+        "least_value_eviction": false,
+    }
+    
+}

--- a/rlfd/rlfd.go
+++ b/rlfd/rlfd.go
@@ -9,16 +9,16 @@ import (
 
 var _ = fmt.Println
 
-// TODO(hao): make the RLFD configurable
+// TODO: make the RLFD configurable
 const (
     //number of counters in a virtual counter node
-    m = uint32(8)
+    // m = uint32(8)
+    m = uint32(128)
     //s = log2(m)
-    // TODO(hao): what is s?
-    s = uint32(3)
+    s = uint32(7)
     //must hold: s * d < 32
     //depth of the virtual counter tree
-    d = uint32(7)
+    d = uint32(4)
     //must hold: d >= roundUp(logm(n)) (n = number of flows)
 )
 


### PR DESCRIPTION
To verify whether the current implementation works without bugs, I try to reproduce the simulation results from our previous emulator written in JAVA, in which we generate synthetic traces for experiments.

Here I load the synthetic trace of flat large flows and evaluate EARDet and RLFD over it. The results looks similar to the ones we got in previous simulation. For RLFD, the FN from CAIDA trace is much more than that the synthetic one, probably because many out-of-spec flows in CAIDA have a short lifetime and do not come back again for RLFD to detect.

@simonschdev if you have a chance, it would be nice to make the RLFD's counter structure configurable by parameters, because it may also effect the performance, and we may want to play with it with different settings. If you don't have a chance, I will do that next time. Thank you! Also should we replace murmur3 hash with AES hash ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lfd/13)
<!-- Reviewable:end -->
